### PR TITLE
Switches rename

### DIFF
--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -872,6 +872,34 @@ fn switch_exceptions() -> Vec<RsTypException> {
             new_rs_typ: "Cw",
             emit: false,
         },
+        RsTypException {
+            module: "render",
+            rs_typ: "CreatePictureValueList",
+            new_module: None,
+            new_rs_typ: "Cp",
+            emit: true,
+        },
+        RsTypException {
+            module: "render",
+            rs_typ: "ChangePictureValueList",
+            new_module: None,
+            new_rs_typ: "Cp",
+            emit: false,
+        },
+        RsTypException {
+            module: "sync",
+            rs_typ: "CreateAlarmValueList",
+            new_module: None,
+            new_rs_typ: "Ca",
+            emit: true,
+        },
+        RsTypException {
+            module: "sync",
+            rs_typ: "ChangeAlarmValueList",
+            new_module: None,
+            new_rs_typ: "Ca",
+            emit: false,
+        },
     ]
 }
 
@@ -903,6 +931,20 @@ fn mask_exceptions() -> Vec<RsTypException> {
             rs_typ: "Kb",
             new_module: None,
             new_rs_typ: "KbMask",
+            emit: true,
+        },
+        RsTypException {
+            module: "render",
+            rs_typ: "Cp",
+            new_module: None,
+            new_rs_typ: "CpMask",
+            emit: true,
+        },
+        RsTypException {
+            module: "sync",
+            rs_typ: "Ca",
+            new_module: None,
+            new_rs_typ: "CaMask",
             emit: true,
         },
     ]


### PR DESCRIPTION
Aim is more ergonomic type names for parameters of `render::CreatePicture`, `render::ChangePicture`, `sync::CreateAlarm` and `sync::ChangeAlarm`.

The diff of generated code is as follow:
```diff
diff -ur gen/previous/render.rs gen/current/render.rs
--- gen/previous/render.rs	2021-11-14 21:53:23.360727270 +0100
+++ gen/current/render.rs	2021-11-15 11:34:45.063334376 +0100
@@ -557,7 +557,7 @@
 }
 
 bitflags! {
-    pub struct Cp: u32 {
+    pub struct CpMask: u32 {
         const REPEAT = 0x00000001;
         const ALPHA_MAP = 0x00000002;
         const ALPHA_X_ORIGIN = 0x00000004;
@@ -1499,12 +1499,12 @@
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct CreatePictureValueListParams {
+pub struct CpParams {
     pub value_mask: usize,
 }
 
 #[derive(Clone, Debug)]
-pub enum CreatePictureValueList {
+pub enum Cp {
     Repeat(u32),
     AlphaMap(Picture),
     AlphaXOrigin(i32),
@@ -1520,56 +1520,56 @@
     ComponentAlpha(u32),
 }
 
-impl CreatePictureValueList {
-    pub(crate) fn get_mask(slice: &[CreatePictureValueList]) -> Cp {
-        let mut res = Cp::empty();
+impl Cp {
+    pub(crate) fn get_mask(slice: &[Cp]) -> CpMask {
+        let mut res = CpMask::empty();
         for el in slice {
             match el {
-                CreatePictureValueList::Repeat { .. } => {
-                    res |= Cp::REPEAT;
+                Cp::Repeat { .. } => {
+                    res |= CpMask::REPEAT;
                 }
-                CreatePictureValueList::AlphaMap { .. } => {
-                    res |= Cp::ALPHA_MAP;
+                Cp::AlphaMap { .. } => {
+                    res |= CpMask::ALPHA_MAP;
                 }
-                CreatePictureValueList::AlphaXOrigin { .. } => {
-                    res |= Cp::ALPHA_X_ORIGIN;
+                Cp::AlphaXOrigin { .. } => {
+                    res |= CpMask::ALPHA_X_ORIGIN;
                 }
-                CreatePictureValueList::AlphaYOrigin { .. } => {
-                    res |= Cp::ALPHA_Y_ORIGIN;
+                Cp::AlphaYOrigin { .. } => {
+                    res |= CpMask::ALPHA_Y_ORIGIN;
                 }
-                CreatePictureValueList::ClipXOrigin { .. } => {
-                    res |= Cp::CLIP_X_ORIGIN;
+                Cp::ClipXOrigin { .. } => {
+                    res |= CpMask::CLIP_X_ORIGIN;
                 }
-                CreatePictureValueList::ClipYOrigin { .. } => {
-                    res |= Cp::CLIP_Y_ORIGIN;
+                Cp::ClipYOrigin { .. } => {
+                    res |= CpMask::CLIP_Y_ORIGIN;
                 }
-                CreatePictureValueList::ClipMask { .. } => {
-                    res |= Cp::CLIP_MASK;
+                Cp::ClipMask { .. } => {
+                    res |= CpMask::CLIP_MASK;
                 }
-                CreatePictureValueList::GraphicsExposure { .. } => {
-                    res |= Cp::GRAPHICS_EXPOSURE;
+                Cp::GraphicsExposure { .. } => {
+                    res |= CpMask::GRAPHICS_EXPOSURE;
                 }
-                CreatePictureValueList::SubwindowMode { .. } => {
-                    res |= Cp::SUBWINDOW_MODE;
+                Cp::SubwindowMode { .. } => {
+                    res |= CpMask::SUBWINDOW_MODE;
                 }
-                CreatePictureValueList::PolyEdge { .. } => {
-                    res |= Cp::POLY_EDGE;
+                Cp::PolyEdge { .. } => {
+                    res |= CpMask::POLY_EDGE;
                 }
-                CreatePictureValueList::PolyMode { .. } => {
-                    res |= Cp::POLY_MODE;
+                Cp::PolyMode { .. } => {
+                    res |= CpMask::POLY_MODE;
                 }
-                CreatePictureValueList::Dither { .. } => {
-                    res |= Cp::DITHER;
+                Cp::Dither { .. } => {
+                    res |= CpMask::DITHER;
                 }
-                CreatePictureValueList::ComponentAlpha { .. } => {
-                    res |= Cp::COMPONENT_ALPHA;
+                Cp::ComponentAlpha { .. } => {
+                    res |= CpMask::COMPONENT_ALPHA;
                 }
             }
         }
         res
     }
 
-    pub(crate) fn is_sorted_distinct(slice: &[CreatePictureValueList]) -> bool {
+    pub(crate) fn is_sorted_distinct(slice: &[Cp]) -> bool {
         if slice.len() <= 1 {
             true
         } else {
@@ -1584,79 +1584,79 @@
 
     fn get_ord(&self) -> u32 {
         match self {
-            CreatePictureValueList::Repeat { .. } => 0,
-            CreatePictureValueList::AlphaMap { .. } => 1,
-            CreatePictureValueList::AlphaXOrigin { .. } => 2,
-            CreatePictureValueList::AlphaYOrigin { .. } => 3,
-            CreatePictureValueList::ClipXOrigin { .. } => 4,
-            CreatePictureValueList::ClipYOrigin { .. } => 5,
-            CreatePictureValueList::ClipMask { .. } => 6,
-            CreatePictureValueList::GraphicsExposure { .. } => 7,
-            CreatePictureValueList::SubwindowMode { .. } => 8,
-            CreatePictureValueList::PolyEdge { .. } => 9,
-            CreatePictureValueList::PolyMode { .. } => 10,
-            CreatePictureValueList::Dither { .. } => 11,
-            CreatePictureValueList::ComponentAlpha { .. } => 12,
+            Cp::Repeat { .. } => 0,
+            Cp::AlphaMap { .. } => 1,
+            Cp::AlphaXOrigin { .. } => 2,
+            Cp::AlphaYOrigin { .. } => 3,
+            Cp::ClipXOrigin { .. } => 4,
+            Cp::ClipYOrigin { .. } => 5,
+            Cp::ClipMask { .. } => 6,
+            Cp::GraphicsExposure { .. } => 7,
+            Cp::SubwindowMode { .. } => 8,
+            Cp::PolyEdge { .. } => 9,
+            Cp::PolyMode { .. } => 10,
+            Cp::Dither { .. } => 11,
+            Cp::ComponentAlpha { .. } => 12,
         }
     }
 }
 
-impl base::Wired for &[CreatePictureValueList] {
-    type Params = CreatePictureValueListParams;
+impl base::Wired for &[Cp] {
+    type Params = CpParams;
 
     unsafe fn compute_wire_len(ptr: *const u8, params: Self::Params) -> usize {
-        let CreatePictureValueListParams { value_mask } = params;
+        let CpParams { value_mask } = params;
         let expr = (value_mask as usize);
         let mut sz = 0usize;
-        if expr & (Cp::REPEAT.bits() as usize) != 0 {
+        if expr & (CpMask::REPEAT.bits() as usize) != 0 {
             // repeat
             sz += 4usize;
         }
-        if expr & (Cp::ALPHA_MAP.bits() as usize) != 0 {
+        if expr & (CpMask::ALPHA_MAP.bits() as usize) != 0 {
             // alphamap
             sz += 4usize;
         }
-        if expr & (Cp::ALPHA_X_ORIGIN.bits() as usize) != 0 {
+        if expr & (CpMask::ALPHA_X_ORIGIN.bits() as usize) != 0 {
             // alphaxorigin
             sz += 4usize;
         }
-        if expr & (Cp::ALPHA_Y_ORIGIN.bits() as usize) != 0 {
+        if expr & (CpMask::ALPHA_Y_ORIGIN.bits() as usize) != 0 {
             // alphayorigin
             sz += 4usize;
         }
-        if expr & (Cp::CLIP_X_ORIGIN.bits() as usize) != 0 {
+        if expr & (CpMask::CLIP_X_ORIGIN.bits() as usize) != 0 {
             // clipxorigin
             sz += 4usize;
         }
-        if expr & (Cp::CLIP_Y_ORIGIN.bits() as usize) != 0 {
+        if expr & (CpMask::CLIP_Y_ORIGIN.bits() as usize) != 0 {
             // clipyorigin
             sz += 4usize;
         }
-        if expr & (Cp::CLIP_MASK.bits() as usize) != 0 {
+        if expr & (CpMask::CLIP_MASK.bits() as usize) != 0 {
             // clipmask
             sz += 4usize;
         }
-        if expr & (Cp::GRAPHICS_EXPOSURE.bits() as usize) != 0 {
+        if expr & (CpMask::GRAPHICS_EXPOSURE.bits() as usize) != 0 {
             // graphicsexposure
             sz += 4usize;
         }
-        if expr & (Cp::SUBWINDOW_MODE.bits() as usize) != 0 {
+        if expr & (CpMask::SUBWINDOW_MODE.bits() as usize) != 0 {
             // subwindowmode
             sz += 4usize;
         }
-        if expr & (Cp::POLY_EDGE.bits() as usize) != 0 {
+        if expr & (CpMask::POLY_EDGE.bits() as usize) != 0 {
             // polyedge
             sz += 4usize;
         }
-        if expr & (Cp::POLY_MODE.bits() as usize) != 0 {
+        if expr & (CpMask::POLY_MODE.bits() as usize) != 0 {
             // polymode
             sz += 4usize;
         }
-        if expr & (Cp::DITHER.bits() as usize) != 0 {
+        if expr & (CpMask::DITHER.bits() as usize) != 0 {
             // dither
             sz += 4usize;
         }
-        if expr & (Cp::COMPONENT_ALPHA.bits() as usize) != 0 {
+        if expr & (CpMask::COMPONENT_ALPHA.bits() as usize) != 0 {
             // componentalpha
             sz += 4usize;
         }
@@ -1667,43 +1667,43 @@
         let mut sz = 0usize;
         for el in self.iter() {
             match el {
-                CreatePictureValueList::Repeat(repeat) => {
+                Cp::Repeat(repeat) => {
                     sz += 4;
                 }
-                CreatePictureValueList::AlphaMap(alphamap) => {
+                Cp::AlphaMap(alphamap) => {
                     sz += 4;
                 }
-                CreatePictureValueList::AlphaXOrigin(alphaxorigin) => {
+                Cp::AlphaXOrigin(alphaxorigin) => {
                     sz += 4;
                 }
-                CreatePictureValueList::AlphaYOrigin(alphayorigin) => {
+                Cp::AlphaYOrigin(alphayorigin) => {
                     sz += 4;
                 }
-                CreatePictureValueList::ClipXOrigin(clipxorigin) => {
+                Cp::ClipXOrigin(clipxorigin) => {
                     sz += 4;
                 }
-                CreatePictureValueList::ClipYOrigin(clipyorigin) => {
+                Cp::ClipYOrigin(clipyorigin) => {
                     sz += 4;
                 }
-                CreatePictureValueList::ClipMask(clipmask) => {
+                Cp::ClipMask(clipmask) => {
                     sz += 4;
                 }
-                CreatePictureValueList::GraphicsExposure(graphicsexposure) => {
+                Cp::GraphicsExposure(graphicsexposure) => {
                     sz += 4;
                 }
-                CreatePictureValueList::SubwindowMode(subwindowmode) => {
+                Cp::SubwindowMode(subwindowmode) => {
                     sz += 4;
                 }
-                CreatePictureValueList::PolyEdge(polyedge) => {
+                Cp::PolyEdge(polyedge) => {
                     sz += 4;
                 }
-                CreatePictureValueList::PolyMode(polymode) => {
+                Cp::PolyMode(polymode) => {
                     sz += 4;
                 }
-                CreatePictureValueList::Dither(dither) => {
+                Cp::Dither(dither) => {
                     sz += 4;
                 }
-                CreatePictureValueList::ComponentAlpha(componentalpha) => {
+                Cp::ComponentAlpha(componentalpha) => {
                     sz += 4;
                 }
             }
@@ -1715,305 +1715,43 @@
         let mut offset = 0usize;
         for el in self.iter() {
             match el {
-                CreatePictureValueList::Repeat(repeat) => {
+                Cp::Repeat(repeat) => {
                     offset += repeat.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::AlphaMap(alphamap) => {
+                Cp::AlphaMap(alphamap) => {
                     offset += alphamap.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::AlphaXOrigin(alphaxorigin) => {
+                Cp::AlphaXOrigin(alphaxorigin) => {
                     offset += alphaxorigin.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::AlphaYOrigin(alphayorigin) => {
+                Cp::AlphaYOrigin(alphayorigin) => {
                     offset += alphayorigin.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::ClipXOrigin(clipxorigin) => {
+                Cp::ClipXOrigin(clipxorigin) => {
                     offset += clipxorigin.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::ClipYOrigin(clipyorigin) => {
+                Cp::ClipYOrigin(clipyorigin) => {
                     offset += clipyorigin.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::ClipMask(clipmask) => {
+                Cp::ClipMask(clipmask) => {
                     offset += clipmask.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::GraphicsExposure(graphicsexposure) => {
+                Cp::GraphicsExposure(graphicsexposure) => {
                     offset += graphicsexposure.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::SubwindowMode(subwindowmode) => {
+                Cp::SubwindowMode(subwindowmode) => {
                     offset += subwindowmode.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::PolyEdge(polyedge) => {
+                Cp::PolyEdge(polyedge) => {
                     offset += polyedge.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::PolyMode(polymode) => {
+                Cp::PolyMode(polymode) => {
                     offset += polymode.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::Dither(dither) => {
+                Cp::Dither(dither) => {
                     offset += dither.serialize(&mut wire_buf[offset..]);
                 }
-                CreatePictureValueList::ComponentAlpha(componentalpha) => {
-                    offset += componentalpha.serialize(&mut wire_buf[offset..]);
-                }
-            }
-        }
-        offset
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct ChangePictureValueListParams {
-    pub value_mask: usize,
-}
-
-#[derive(Clone, Debug)]
-pub enum ChangePictureValueList {
-    Repeat(u32),
-    AlphaMap(Picture),
-    AlphaXOrigin(i32),
-    AlphaYOrigin(i32),
-    ClipXOrigin(i32),
-    ClipYOrigin(i32),
-    ClipMask(xproto::Pixmap),
-    GraphicsExposure(u32),
-    SubwindowMode(u32),
-    PolyEdge(u32),
-    PolyMode(u32),
-    Dither(xproto::Atom),
-    ComponentAlpha(u32),
-}
-
-impl ChangePictureValueList {
-    pub(crate) fn get_mask(slice: &[ChangePictureValueList]) -> Cp {
-        let mut res = Cp::empty();
-        for el in slice {
-            match el {
-                ChangePictureValueList::Repeat { .. } => {
-                    res |= Cp::REPEAT;
-                }
-                ChangePictureValueList::AlphaMap { .. } => {
-                    res |= Cp::ALPHA_MAP;
-                }
-                ChangePictureValueList::AlphaXOrigin { .. } => {
-                    res |= Cp::ALPHA_X_ORIGIN;
-                }
-                ChangePictureValueList::AlphaYOrigin { .. } => {
-                    res |= Cp::ALPHA_Y_ORIGIN;
-                }
-                ChangePictureValueList::ClipXOrigin { .. } => {
-                    res |= Cp::CLIP_X_ORIGIN;
-                }
-                ChangePictureValueList::ClipYOrigin { .. } => {
-                    res |= Cp::CLIP_Y_ORIGIN;
-                }
-                ChangePictureValueList::ClipMask { .. } => {
-                    res |= Cp::CLIP_MASK;
-                }
-                ChangePictureValueList::GraphicsExposure { .. } => {
-                    res |= Cp::GRAPHICS_EXPOSURE;
-                }
-                ChangePictureValueList::SubwindowMode { .. } => {
-                    res |= Cp::SUBWINDOW_MODE;
-                }
-                ChangePictureValueList::PolyEdge { .. } => {
-                    res |= Cp::POLY_EDGE;
-                }
-                ChangePictureValueList::PolyMode { .. } => {
-                    res |= Cp::POLY_MODE;
-                }
-                ChangePictureValueList::Dither { .. } => {
-                    res |= Cp::DITHER;
-                }
-                ChangePictureValueList::ComponentAlpha { .. } => {
-                    res |= Cp::COMPONENT_ALPHA;
-                }
-            }
-        }
-        res
-    }
-
-    pub(crate) fn is_sorted_distinct(slice: &[ChangePictureValueList]) -> bool {
-        if slice.len() <= 1 {
-            true
-        } else {
-            let mut last = slice[0].get_ord();
-            slice[1..].iter().map(|el| el.get_ord()).all(|o| {
-                let lasto = last;
-                last = o;
-                lasto < o
-            })
-        }
-    }
-
-    fn get_ord(&self) -> u32 {
-        match self {
-            ChangePictureValueList::Repeat { .. } => 0,
-            ChangePictureValueList::AlphaMap { .. } => 1,
-            ChangePictureValueList::AlphaXOrigin { .. } => 2,
-            ChangePictureValueList::AlphaYOrigin { .. } => 3,
-            ChangePictureValueList::ClipXOrigin { .. } => 4,
-            ChangePictureValueList::ClipYOrigin { .. } => 5,
-            ChangePictureValueList::ClipMask { .. } => 6,
-            ChangePictureValueList::GraphicsExposure { .. } => 7,
-            ChangePictureValueList::SubwindowMode { .. } => 8,
-            ChangePictureValueList::PolyEdge { .. } => 9,
-            ChangePictureValueList::PolyMode { .. } => 10,
-            ChangePictureValueList::Dither { .. } => 11,
-            ChangePictureValueList::ComponentAlpha { .. } => 12,
-        }
-    }
-}
-
-impl base::Wired for &[ChangePictureValueList] {
-    type Params = ChangePictureValueListParams;
-
-    unsafe fn compute_wire_len(ptr: *const u8, params: Self::Params) -> usize {
-        let ChangePictureValueListParams { value_mask } = params;
-        let expr = (value_mask as usize);
-        let mut sz = 0usize;
-        if expr & (Cp::REPEAT.bits() as usize) != 0 {
-            // repeat
-            sz += 4usize;
-        }
-        if expr & (Cp::ALPHA_MAP.bits() as usize) != 0 {
-            // alphamap
-            sz += 4usize;
-        }
-        if expr & (Cp::ALPHA_X_ORIGIN.bits() as usize) != 0 {
-            // alphaxorigin
-            sz += 4usize;
-        }
-        if expr & (Cp::ALPHA_Y_ORIGIN.bits() as usize) != 0 {
-            // alphayorigin
-            sz += 4usize;
-        }
-        if expr & (Cp::CLIP_X_ORIGIN.bits() as usize) != 0 {
-            // clipxorigin
-            sz += 4usize;
-        }
-        if expr & (Cp::CLIP_Y_ORIGIN.bits() as usize) != 0 {
-            // clipyorigin
-            sz += 4usize;
-        }
-        if expr & (Cp::CLIP_MASK.bits() as usize) != 0 {
-            // clipmask
-            sz += 4usize;
-        }
-        if expr & (Cp::GRAPHICS_EXPOSURE.bits() as usize) != 0 {
-            // graphicsexposure
-            sz += 4usize;
-        }
-        if expr & (Cp::SUBWINDOW_MODE.bits() as usize) != 0 {
-            // subwindowmode
-            sz += 4usize;
-        }
-        if expr & (Cp::POLY_EDGE.bits() as usize) != 0 {
-            // polyedge
-            sz += 4usize;
-        }
-        if expr & (Cp::POLY_MODE.bits() as usize) != 0 {
-            // polymode
-            sz += 4usize;
-        }
-        if expr & (Cp::DITHER.bits() as usize) != 0 {
-            // dither
-            sz += 4usize;
-        }
-        if expr & (Cp::COMPONENT_ALPHA.bits() as usize) != 0 {
-            // componentalpha
-            sz += 4usize;
-        }
-        sz
-    }
-
-    fn wire_len(&self) -> usize {
-        let mut sz = 0usize;
-        for el in self.iter() {
-            match el {
-                ChangePictureValueList::Repeat(repeat) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::AlphaMap(alphamap) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::AlphaXOrigin(alphaxorigin) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::AlphaYOrigin(alphayorigin) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::ClipXOrigin(clipxorigin) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::ClipYOrigin(clipyorigin) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::ClipMask(clipmask) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::GraphicsExposure(graphicsexposure) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::SubwindowMode(subwindowmode) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::PolyEdge(polyedge) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::PolyMode(polymode) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::Dither(dither) => {
-                    sz += 4;
-                }
-                ChangePictureValueList::ComponentAlpha(componentalpha) => {
-                    sz += 4;
-                }
-            }
-        }
-        sz
-    }
-
-    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
-        let mut offset = 0usize;
-        for el in self.iter() {
-            match el {
-                ChangePictureValueList::Repeat(repeat) => {
-                    offset += repeat.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::AlphaMap(alphamap) => {
-                    offset += alphamap.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::AlphaXOrigin(alphaxorigin) => {
-                    offset += alphaxorigin.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::AlphaYOrigin(alphayorigin) => {
-                    offset += alphayorigin.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::ClipXOrigin(clipxorigin) => {
-                    offset += clipxorigin.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::ClipYOrigin(clipyorigin) => {
-                    offset += clipyorigin.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::ClipMask(clipmask) => {
-                    offset += clipmask.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::GraphicsExposure(graphicsexposure) => {
-                    offset += graphicsexposure.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::SubwindowMode(subwindowmode) => {
-                    offset += subwindowmode.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::PolyEdge(polyedge) => {
-                    offset += polyedge.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::PolyMode(polymode) => {
-                    offset += polymode.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::Dither(dither) => {
-                    offset += dither.serialize(&mut wire_buf[offset..]);
-                }
-                ChangePictureValueList::ComponentAlpha(componentalpha) => {
+                Cp::ComponentAlpha(componentalpha) => {
                     offset += componentalpha.serialize(&mut wire_buf[offset..]);
                 }
             }
@@ -2731,14 +2469,14 @@
     pub pid: Picture,
     pub drawable: xproto::Drawable,
     pub format: Pictformat,
-    pub value_list: &'a [CreatePictureValueList],
+    pub value_list: &'a [Cp],
 }
 
 unsafe impl<'a> base::RawRequest for CreatePicture<'a> {
     fn raw_request(&self, c: &base::Connection, checked: bool) -> u64 {
         unsafe {
             assert!(
-                CreatePictureValueList::is_sorted_distinct(self.value_list),
+                Cp::is_sorted_distinct(self.value_list),
                 "CreatePicture::value_list must be sorted!"
             );
             let mut protocol_request = xcb_protocol_request_t {
@@ -2757,8 +2495,7 @@
             self.pid.serialize(&mut buf0[4..]);
             self.drawable.serialize(&mut buf0[8..]);
             self.format.serialize(&mut buf0[12..]);
-            (CreatePictureValueList::get_mask(self.value_list).bits() as u32)
-                .serialize(&mut buf0[16..]);
+            (Cp::get_mask(self.value_list).bits() as u32).serialize(&mut buf0[16..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
             sections[2].iov_len = 20;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
@@ -2793,14 +2530,14 @@
 #[derive(Clone, Debug)]
 pub struct ChangePicture<'a> {
     pub picture: Picture,
-    pub value_list: &'a [ChangePictureValueList],
+    pub value_list: &'a [Cp],
 }
 
 unsafe impl<'a> base::RawRequest for ChangePicture<'a> {
     fn raw_request(&self, c: &base::Connection, checked: bool) -> u64 {
         unsafe {
             assert!(
-                ChangePictureValueList::is_sorted_distinct(self.value_list),
+                Cp::is_sorted_distinct(self.value_list),
                 "ChangePicture::value_list must be sorted!"
             );
             let mut protocol_request = xcb_protocol_request_t {
@@ -2817,8 +2554,7 @@
 
             let buf0: &mut [u8] = &mut [0; 12];
             self.picture.serialize(&mut buf0[4..]);
-            (ChangePictureValueList::get_mask(self.value_list).bits() as u32)
-                .serialize(&mut buf0[8..]);
+            (Cp::get_mask(self.value_list).bits() as u32).serialize(&mut buf0[8..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
             sections[2].iov_len = 12;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
diff -ur gen/previous/sync.rs gen/current/sync.rs
--- gen/previous/sync.rs	2021-11-14 21:53:24.024056964 +0100
+++ gen/current/sync.rs	2021-11-15 11:34:45.863334377 +0100
@@ -730,7 +730,7 @@
 }
 
 bitflags! {
-    pub struct Ca: u32 {
+    pub struct CaMask: u32 {
         const COUNTER = 0x00000001;
         const VALUE_TYPE = 0x00000002;
         const VALUE = 0x00000004;
@@ -1109,12 +1109,12 @@
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct CreateAlarmValueListParams {
+pub struct CaParams {
     pub value_mask: usize,
 }
 
 #[derive(Clone, Debug)]
-pub enum CreateAlarmValueList {
+pub enum Ca {
     Counter(Counter),
     ValueType(u32),
     Value(Int64),
@@ -1123,35 +1123,35 @@
     Events(u32),
 }
 
-impl CreateAlarmValueList {
-    pub(crate) fn get_mask(slice: &[CreateAlarmValueList]) -> Ca {
-        let mut res = Ca::empty();
+impl Ca {
+    pub(crate) fn get_mask(slice: &[Ca]) -> CaMask {
+        let mut res = CaMask::empty();
         for el in slice {
             match el {
-                CreateAlarmValueList::Counter { .. } => {
-                    res |= Ca::COUNTER;
+                Ca::Counter { .. } => {
+                    res |= CaMask::COUNTER;
                 }
-                CreateAlarmValueList::ValueType { .. } => {
-                    res |= Ca::VALUE_TYPE;
+                Ca::ValueType { .. } => {
+                    res |= CaMask::VALUE_TYPE;
                 }
-                CreateAlarmValueList::Value { .. } => {
-                    res |= Ca::VALUE;
+                Ca::Value { .. } => {
+                    res |= CaMask::VALUE;
                 }
-                CreateAlarmValueList::TestType { .. } => {
-                    res |= Ca::TEST_TYPE;
+                Ca::TestType { .. } => {
+                    res |= CaMask::TEST_TYPE;
                 }
-                CreateAlarmValueList::Delta { .. } => {
-                    res |= Ca::DELTA;
+                Ca::Delta { .. } => {
+                    res |= CaMask::DELTA;
                 }
-                CreateAlarmValueList::Events { .. } => {
-                    res |= Ca::EVENTS;
+                Ca::Events { .. } => {
+                    res |= CaMask::EVENTS;
                 }
             }
         }
         res
     }
 
-    pub(crate) fn is_sorted_distinct(slice: &[CreateAlarmValueList]) -> bool {
+    pub(crate) fn is_sorted_distinct(slice: &[Ca]) -> bool {
         if slice.len() <= 1 {
             true
         } else {
@@ -1166,44 +1166,44 @@
 
     fn get_ord(&self) -> u32 {
         match self {
-            CreateAlarmValueList::Counter { .. } => 0,
-            CreateAlarmValueList::ValueType { .. } => 1,
-            CreateAlarmValueList::Value { .. } => 2,
-            CreateAlarmValueList::TestType { .. } => 3,
-            CreateAlarmValueList::Delta { .. } => 4,
-            CreateAlarmValueList::Events { .. } => 5,
+            Ca::Counter { .. } => 0,
+            Ca::ValueType { .. } => 1,
+            Ca::Value { .. } => 2,
+            Ca::TestType { .. } => 3,
+            Ca::Delta { .. } => 4,
+            Ca::Events { .. } => 5,
         }
     }
 }
 
-impl base::Wired for &[CreateAlarmValueList] {
-    type Params = CreateAlarmValueListParams;
+impl base::Wired for &[Ca] {
+    type Params = CaParams;
 
     unsafe fn compute_wire_len(ptr: *const u8, params: Self::Params) -> usize {
-        let CreateAlarmValueListParams { value_mask } = params;
+        let CaParams { value_mask } = params;
         let expr = (value_mask as usize);
         let mut sz = 0usize;
-        if expr & (Ca::COUNTER.bits() as usize) != 0 {
+        if expr & (CaMask::COUNTER.bits() as usize) != 0 {
             // counter
             sz += 4usize;
         }
-        if expr & (Ca::VALUE_TYPE.bits() as usize) != 0 {
+        if expr & (CaMask::VALUE_TYPE.bits() as usize) != 0 {
             // value_type
             sz += 4usize;
         }
-        if expr & (Ca::VALUE.bits() as usize) != 0 {
+        if expr & (CaMask::VALUE.bits() as usize) != 0 {
             // value
             sz += 8usize;
         }
-        if expr & (Ca::TEST_TYPE.bits() as usize) != 0 {
+        if expr & (CaMask::TEST_TYPE.bits() as usize) != 0 {
             // test_type
             sz += 4usize;
         }
-        if expr & (Ca::DELTA.bits() as usize) != 0 {
+        if expr & (CaMask::DELTA.bits() as usize) != 0 {
             // delta
             sz += 8usize;
         }
-        if expr & (Ca::EVENTS.bits() as usize) != 0 {
+        if expr & (CaMask::EVENTS.bits() as usize) != 0 {
             // events
             sz += 4usize;
         }
@@ -1214,22 +1214,22 @@
         let mut sz = 0usize;
         for el in self.iter() {
             match el {
-                CreateAlarmValueList::Counter(counter) => {
+                Ca::Counter(counter) => {
                     sz += 4;
                 }
-                CreateAlarmValueList::ValueType(value_type) => {
+                Ca::ValueType(value_type) => {
                     sz += 4;
                 }
-                CreateAlarmValueList::Value(value) => {
+                Ca::Value(value) => {
                     sz += 8;
                 }
-                CreateAlarmValueList::TestType(test_type) => {
+                Ca::TestType(test_type) => {
                     sz += 4;
                 }
-                CreateAlarmValueList::Delta(delta) => {
+                Ca::Delta(delta) => {
                     sz += 8;
                 }
-                CreateAlarmValueList::Events(events) => {
+                Ca::Events(events) => {
                     sz += 4;
                 }
             }
@@ -1241,179 +1241,22 @@
         let mut offset = 0usize;
         for el in self.iter() {
             match el {
-                CreateAlarmValueList::Counter(counter) => {
+                Ca::Counter(counter) => {
                     offset += counter.serialize(&mut wire_buf[offset..]);
                 }
-                CreateAlarmValueList::ValueType(value_type) => {
+                Ca::ValueType(value_type) => {
                     offset += value_type.serialize(&mut wire_buf[offset..]);
                 }
-                CreateAlarmValueList::Value(value) => {
+                Ca::Value(value) => {
                     offset += value.serialize(&mut wire_buf[offset..]);
                 }
-                CreateAlarmValueList::TestType(test_type) => {
+                Ca::TestType(test_type) => {
                     offset += test_type.serialize(&mut wire_buf[offset..]);
                 }
-                CreateAlarmValueList::Delta(delta) => {
+                Ca::Delta(delta) => {
                     offset += delta.serialize(&mut wire_buf[offset..]);
                 }
-                CreateAlarmValueList::Events(events) => {
-                    offset += events.serialize(&mut wire_buf[offset..]);
-                }
-            }
-        }
-        offset
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct ChangeAlarmValueListParams {
-    pub value_mask: usize,
-}
-
-#[derive(Clone, Debug)]
-pub enum ChangeAlarmValueList {
-    Counter(Counter),
-    ValueType(u32),
-    Value(Int64),
-    TestType(u32),
-    Delta(Int64),
-    Events(u32),
-}
-
-impl ChangeAlarmValueList {
-    pub(crate) fn get_mask(slice: &[ChangeAlarmValueList]) -> Ca {
-        let mut res = Ca::empty();
-        for el in slice {
-            match el {
-                ChangeAlarmValueList::Counter { .. } => {
-                    res |= Ca::COUNTER;
-                }
-                ChangeAlarmValueList::ValueType { .. } => {
-                    res |= Ca::VALUE_TYPE;
-                }
-                ChangeAlarmValueList::Value { .. } => {
-                    res |= Ca::VALUE;
-                }
-                ChangeAlarmValueList::TestType { .. } => {
-                    res |= Ca::TEST_TYPE;
-                }
-                ChangeAlarmValueList::Delta { .. } => {
-                    res |= Ca::DELTA;
-                }
-                ChangeAlarmValueList::Events { .. } => {
-                    res |= Ca::EVENTS;
-                }
-            }
-        }
-        res
-    }
-
-    pub(crate) fn is_sorted_distinct(slice: &[ChangeAlarmValueList]) -> bool {
-        if slice.len() <= 1 {
-            true
-        } else {
-            let mut last = slice[0].get_ord();
-            slice[1..].iter().map(|el| el.get_ord()).all(|o| {
-                let lasto = last;
-                last = o;
-                lasto < o
-            })
-        }
-    }
-
-    fn get_ord(&self) -> u32 {
-        match self {
-            ChangeAlarmValueList::Counter { .. } => 0,
-            ChangeAlarmValueList::ValueType { .. } => 1,
-            ChangeAlarmValueList::Value { .. } => 2,
-            ChangeAlarmValueList::TestType { .. } => 3,
-            ChangeAlarmValueList::Delta { .. } => 4,
-            ChangeAlarmValueList::Events { .. } => 5,
-        }
-    }
-}
-
-impl base::Wired for &[ChangeAlarmValueList] {
-    type Params = ChangeAlarmValueListParams;
-
-    unsafe fn compute_wire_len(ptr: *const u8, params: Self::Params) -> usize {
-        let ChangeAlarmValueListParams { value_mask } = params;
-        let expr = (value_mask as usize);
-        let mut sz = 0usize;
-        if expr & (Ca::COUNTER.bits() as usize) != 0 {
-            // counter
-            sz += 4usize;
-        }
-        if expr & (Ca::VALUE_TYPE.bits() as usize) != 0 {
-            // value_type
-            sz += 4usize;
-        }
-        if expr & (Ca::VALUE.bits() as usize) != 0 {
-            // value
-            sz += 8usize;
-        }
-        if expr & (Ca::TEST_TYPE.bits() as usize) != 0 {
-            // test_type
-            sz += 4usize;
-        }
-        if expr & (Ca::DELTA.bits() as usize) != 0 {
-            // delta
-            sz += 8usize;
-        }
-        if expr & (Ca::EVENTS.bits() as usize) != 0 {
-            // events
-            sz += 4usize;
-        }
-        sz
-    }
-
-    fn wire_len(&self) -> usize {
-        let mut sz = 0usize;
-        for el in self.iter() {
-            match el {
-                ChangeAlarmValueList::Counter(counter) => {
-                    sz += 4;
-                }
-                ChangeAlarmValueList::ValueType(value_type) => {
-                    sz += 4;
-                }
-                ChangeAlarmValueList::Value(value) => {
-                    sz += 8;
-                }
-                ChangeAlarmValueList::TestType(test_type) => {
-                    sz += 4;
-                }
-                ChangeAlarmValueList::Delta(delta) => {
-                    sz += 8;
-                }
-                ChangeAlarmValueList::Events(events) => {
-                    sz += 4;
-                }
-            }
-        }
-        sz
-    }
-
-    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
-        let mut offset = 0usize;
-        for el in self.iter() {
-            match el {
-                ChangeAlarmValueList::Counter(counter) => {
-                    offset += counter.serialize(&mut wire_buf[offset..]);
-                }
-                ChangeAlarmValueList::ValueType(value_type) => {
-                    offset += value_type.serialize(&mut wire_buf[offset..]);
-                }
-                ChangeAlarmValueList::Value(value) => {
-                    offset += value.serialize(&mut wire_buf[offset..]);
-                }
-                ChangeAlarmValueList::TestType(test_type) => {
-                    offset += test_type.serialize(&mut wire_buf[offset..]);
-                }
-                ChangeAlarmValueList::Delta(delta) => {
-                    offset += delta.serialize(&mut wire_buf[offset..]);
-                }
-                ChangeAlarmValueList::Events(events) => {
+                Ca::Events(events) => {
                     offset += events.serialize(&mut wire_buf[offset..]);
                 }
             }
@@ -2229,14 +2072,14 @@
 #[derive(Clone, Debug)]
 pub struct CreateAlarm<'a> {
     pub id: Alarm,
-    pub value_list: &'a [CreateAlarmValueList],
+    pub value_list: &'a [Ca],
 }
 
 unsafe impl<'a> base::RawRequest for CreateAlarm<'a> {
     fn raw_request(&self, c: &base::Connection, checked: bool) -> u64 {
         unsafe {
             assert!(
-                CreateAlarmValueList::is_sorted_distinct(self.value_list),
+                Ca::is_sorted_distinct(self.value_list),
                 "CreateAlarm::value_list must be sorted!"
             );
             let mut protocol_request = xcb_protocol_request_t {
@@ -2253,8 +2096,7 @@
 
             let buf0: &mut [u8] = &mut [0; 12];
             self.id.serialize(&mut buf0[4..]);
-            (CreateAlarmValueList::get_mask(self.value_list).bits() as u32)
-                .serialize(&mut buf0[8..]);
+            (Ca::get_mask(self.value_list).bits() as u32).serialize(&mut buf0[8..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
             sections[2].iov_len = 12;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
@@ -2289,14 +2131,14 @@
 #[derive(Clone, Debug)]
 pub struct ChangeAlarm<'a> {
     pub id: Alarm,
-    pub value_list: &'a [ChangeAlarmValueList],
+    pub value_list: &'a [Ca],
 }
 
 unsafe impl<'a> base::RawRequest for ChangeAlarm<'a> {
     fn raw_request(&self, c: &base::Connection, checked: bool) -> u64 {
         unsafe {
             assert!(
-                ChangeAlarmValueList::is_sorted_distinct(self.value_list),
+                Ca::is_sorted_distinct(self.value_list),
                 "ChangeAlarm::value_list must be sorted!"
             );
             let mut protocol_request = xcb_protocol_request_t {
@@ -2313,8 +2155,7 @@
 
             let buf0: &mut [u8] = &mut [0; 12];
             self.id.serialize(&mut buf0[4..]);
-            (ChangeAlarmValueList::get_mask(self.value_list).bits() as u32)
-                .serialize(&mut buf0[8..]);
+            (Ca::get_mask(self.value_list).bits() as u32).serialize(&mut buf0[8..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
             sections[2].iov_len = 12;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);

```