### PR TITLE
support for <eventstruct> and xinput::SendExtensionEvent

### DIFF
--- a/TODO_v1.md
+++ b/TODO_v1.md
@@ -17,7 +17,7 @@
  - [x] Porting XML examples
  - [x] Documentation
  - [x] Finalize switches naming (e.g. x::CreateWindowValueList -> x::Cw)
- - [ ] Support of xinput::SendExtensionEvent
+ - [x] Support of xinput::SendExtensionEvent
  - [ ] Create example with XInput (pen tablet?)
  - [ ] Create example with Vulkan
  - [ ] Create example with gfx-rs

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -197,6 +197,7 @@ impl CodeGen {
                         struct_style,
                         params_struct,
                         doc,
+                        is_union,
                         ..
                     } = self.get_field_info(name, typ, false, doc);
 
@@ -236,6 +237,7 @@ impl CodeGen {
                         need_compute_offset,
                         params_struct,
                         is_prop,
+                        is_union,
                         doc,
                     });
 
@@ -253,6 +255,7 @@ impl CodeGen {
                         typ,
                         struct_style,
                         params_struct,
+                        is_union,
                         doc,
                         ..
                     } = self.get_field_info(name, typ, false, doc);
@@ -272,6 +275,7 @@ impl CodeGen {
                         len_expr: Expr::UntilEnd,
                         need_compute_offset,
                         is_prop,
+                        is_union,
                         doc,
                     });
 

--- a/build/cg/union.rs
+++ b/build/cg/union.rs
@@ -32,6 +32,7 @@ impl CodeGen {
             variants,
             wire_sz,
             type_field,
+            impl_clone: true,
         };
         self.register_typ(typ.to_string(), typ_info);
     }
@@ -187,9 +188,14 @@ impl CodeGen {
         variants: &[UnionVariant],
         wire_sz: &Expr,
         type_field: &Option<UnionTypeField>,
+        impl_clone: bool,
     ) -> io::Result<()> {
         writeln!(out)?;
-        writeln!(out, "#[derive(Clone, Debug)]")?;
+        writeln!(
+            out,
+            "#[derive({}Debug)]",
+            if impl_clone { "Clone, " } else { "" }
+        )?;
         writeln!(out, "pub enum {} {{", rs_typ)?;
         for v in variants {
             match &v.content {


### PR DESCRIPTION
This collaterally `impl Wired` for all events and fixes a serialization bug (wrong fixed/var sections)

The most interesting diff is `xinput`:
```diff
--- gen/previous/xinput.rs	2021-11-16 23:29:51.666673467 +0100
+++ gen/current/xinput.rs	2021-11-16 23:32:09.240007180 +0100
@@ -606,6 +606,24 @@
     }
 }
 
+impl base::Wired for DeviceValuatorEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceValuatorEvent {
     fn drop(&mut self) {
         unsafe {
@@ -821,6 +839,24 @@
     }
 }
 
+impl base::Wired for DeviceKeyPressEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceKeyPressEvent {
     fn drop(&mut self) {
         unsafe {
@@ -975,6 +1011,24 @@
     }
 }
 
+impl base::Wired for DeviceFocusInEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceFocusInEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1173,6 +1227,24 @@
     }
 }
 
+impl base::Wired for DeviceStateNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceStateNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1315,6 +1387,24 @@
     }
 }
 
+impl base::Wired for DeviceMappingNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceMappingNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1434,6 +1524,24 @@
     }
 }
 
+impl base::Wired for ChangeDeviceNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for ChangeDeviceNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1537,6 +1645,24 @@
     }
 }
 
+impl base::Wired for DeviceKeyStateNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceKeyStateNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1640,6 +1766,24 @@
     }
 }
 
+impl base::Wired for DeviceButtonStateNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceButtonStateNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1771,6 +1915,24 @@
     }
 }
 
+impl base::Wired for DevicePresenceNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DevicePresenceNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -1901,6 +2063,24 @@
     }
 }
 
+impl base::Wired for DevicePropertyNotifyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DevicePropertyNotifyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -2065,6 +2245,24 @@
     }
 }
 
+impl base::Wired for DeviceChangedEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for DeviceChangedEvent {
     fn drop(&mut self) {
         unsafe {
@@ -2350,6 +2548,24 @@
     }
 }
 
+impl base::Wired for KeyPressEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for KeyPressEvent {
     fn drop(&mut self) {
         unsafe {
@@ -2638,6 +2854,24 @@
     }
 }
 
+impl base::Wired for ButtonPressEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for ButtonPressEvent {
     fn drop(&mut self) {
         unsafe {
@@ -2907,6 +3141,24 @@
     }
 }
 
+impl base::Wired for EnterEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for EnterEvent {
     fn drop(&mut self) {
         unsafe {
@@ -3068,6 +3320,24 @@
     }
 }
 
+impl base::Wired for HierarchyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for HierarchyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -3210,6 +3480,24 @@
     }
 }
 
+impl base::Wired for PropertyEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for PropertyEvent {
     fn drop(&mut self) {
         unsafe {
@@ -3414,6 +3702,24 @@
     }
 }
 
+impl base::Wired for RawKeyPressEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for RawKeyPressEvent {
     fn drop(&mut self) {
         unsafe {
@@ -3621,6 +3927,24 @@
     }
 }
 
+impl base::Wired for RawButtonPressEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for RawButtonPressEvent {
     fn drop(&mut self) {
         unsafe {
@@ -3912,6 +4236,24 @@
     }
 }
 
+impl base::Wired for TouchBeginEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for TouchBeginEvent {
     fn drop(&mut self) {
         unsafe {
@@ -4097,6 +4439,24 @@
     }
 }
 
+impl base::Wired for TouchOwnershipEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for TouchOwnershipEvent {
     fn drop(&mut self) {
         unsafe {
@@ -4301,6 +4661,24 @@
     }
 }
 
+impl base::Wired for RawTouchBeginEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for RawTouchBeginEvent {
     fn drop(&mut self) {
         unsafe {
@@ -4530,6 +4908,24 @@
     }
 }
 
+impl base::Wired for BarrierHitEvent {
+    type Params = ();
+
+    unsafe fn compute_wire_len(ptr: *const u8, _params: ()) -> usize {
+        *(ptr.add(4) as *const u32) as usize
+    }
+
+    fn wire_len(&self) -> usize {
+        self.length() as usize
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        debug_assert!(wire_buf.len() >= self.wire_len());
+        (&mut wire_buf[0..self.wire_len()]).copy_from_slice(self.as_slice());
+        self.wire_len()
+    }
+}
+
 impl Drop for BarrierHitEvent {
     fn drop(&mut self) {
         unsafe {
@@ -14300,6 +14696,96 @@
     }
 }
 
+#[derive(Debug)]
+pub enum EventForSend {
+    DeviceValuator(DeviceValuatorEvent),
+    DeviceKeyPress(DeviceKeyPressEvent),
+    DeviceKeyRelease(DeviceKeyReleaseEvent),
+    DeviceButtonPress(DeviceButtonPressEvent),
+    DeviceButtonRelease(DeviceButtonReleaseEvent),
+    DeviceMotionNotify(DeviceMotionNotifyEvent),
+    DeviceFocusIn(DeviceFocusInEvent),
+    DeviceFocusOut(DeviceFocusOutEvent),
+    ProximityIn(ProximityInEvent),
+    ProximityOut(ProximityOutEvent),
+    DeviceStateNotify(DeviceStateNotifyEvent),
+    DeviceMappingNotify(DeviceMappingNotifyEvent),
+    ChangeDeviceNotify(ChangeDeviceNotifyEvent),
+    DeviceKeyStateNotify(DeviceKeyStateNotifyEvent),
+    DeviceButtonStateNotify(DeviceButtonStateNotifyEvent),
+    DevicePresenceNotify(DevicePresenceNotifyEvent),
+    DevicePropertyNotify(DevicePropertyNotifyEvent),
+}
+
+impl base::Wired for EventForSend {
+    type Params = ();
+
+    unsafe fn compute_wire_len(_ptr: *const u8, _params: Self::Params) -> usize {
+        32
+    }
+
+    fn wire_len(&self) -> usize {
+        32
+    }
+
+    fn serialize(&self, wire_buf: &mut [u8]) -> usize {
+        match self {
+            EventForSend::DeviceValuator(device_valuator) => {
+                device_valuator.serialize(wire_buf);
+            }
+            EventForSend::DeviceKeyPress(device_key_press) => {
+                device_key_press.serialize(wire_buf);
+            }
+            EventForSend::DeviceKeyRelease(device_key_release) => {
+                device_key_release.serialize(wire_buf);
+            }
+            EventForSend::DeviceButtonPress(device_button_press) => {
+                device_button_press.serialize(wire_buf);
+            }
+            EventForSend::DeviceButtonRelease(device_button_release) => {
+                device_button_release.serialize(wire_buf);
+            }
+            EventForSend::DeviceMotionNotify(device_motion_notify) => {
+                device_motion_notify.serialize(wire_buf);
+            }
+            EventForSend::DeviceFocusIn(device_focus_in) => {
+                device_focus_in.serialize(wire_buf);
+            }
+            EventForSend::DeviceFocusOut(device_focus_out) => {
+                device_focus_out.serialize(wire_buf);
+            }
+            EventForSend::ProximityIn(proximity_in) => {
+                proximity_in.serialize(wire_buf);
+            }
+            EventForSend::ProximityOut(proximity_out) => {
+                proximity_out.serialize(wire_buf);
+            }
+            EventForSend::DeviceStateNotify(device_state_notify) => {
+                device_state_notify.serialize(wire_buf);
+            }
+            EventForSend::DeviceMappingNotify(device_mapping_notify) => {
+                device_mapping_notify.serialize(wire_buf);
+            }
+            EventForSend::ChangeDeviceNotify(change_device_notify) => {
+                change_device_notify.serialize(wire_buf);
+            }
+            EventForSend::DeviceKeyStateNotify(device_key_state_notify) => {
+                device_key_state_notify.serialize(wire_buf);
+            }
+            EventForSend::DeviceButtonStateNotify(device_button_state_notify) => {
+                device_button_state_notify.serialize(wire_buf);
+            }
+            EventForSend::DevicePresenceNotify(device_presence_notify) => {
+                device_presence_notify.serialize(wire_buf);
+            }
+            EventForSend::DevicePropertyNotify(device_property_notify) => {
+                device_property_notify.serialize(wire_buf);
+            }
+        }
+        32
+    }
+}
+
 /// Reply type for [GetExtensionVersion]
 pub struct GetExtensionVersionReply {
     raw: *const u8,
@@ -21837,9 +22323,8 @@
             sections[2].iov_len = 32;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
-            let buf1: &mut [u8] = &mut [0; 0];
-            sections[4].iov_base = buf1.as_mut_ptr() as *mut _;
-            sections[4].iov_len = 0;
+            sections[4].iov_base = self.mask.as_ptr() as *mut _;
+            sections[4].iov_len = self.mask.len() * std::mem::size_of::<u32>();
             sections[5].iov_len = base::align_pad(sections[4].iov_len, 4);
 
             sections[6].iov_base = self.modifiers.as_ptr() as *mut _;
@@ -22713,3 +23198,71 @@
 }
 
 impl<'a> base::RequestWithoutReply for XiBarrierReleasePointer<'a> {}
+
+/// The `SendExtensionEvent` request.
+#[derive(Clone, Debug)]
+pub struct SendExtensionEvent<'a> {
+    pub destination: xproto::Window,
+    pub device_id: u8,
+    pub propagate: bool,
+    pub events: &'a [EventForSend],
+    pub classes: &'a [EventClass],
+}
+
+unsafe impl<'a> base::RawRequest for SendExtensionEvent<'a> {
+    fn raw_request(&self, c: &base::Connection, checked: bool) -> u64 {
+        unsafe {
+            let mut protocol_request = xcb_protocol_request_t {
+                count: 6,
+                ext: (&mut FFI_EXT) as *mut _,
+                opcode: 31,
+                isvoid: 1,
+            };
+
+            let mut sections: [iovec; 8] = [iovec {
+                iov_base: std::ptr::null_mut(),
+                iov_len: 0,
+            }; 8];
+
+            let buf0: &mut [u8] = &mut [0; 16];
+            self.destination.serialize(&mut buf0[4..]);
+            self.device_id.serialize(&mut buf0[8..]);
+            (if self.propagate { 1u8 } else { 0u8 }).serialize(&mut buf0[9..]);
+            (self.classes.len() as u16).serialize(&mut buf0[10..]);
+            (self.events.len() as u8).serialize(&mut buf0[12..]);
+            sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
+            sections[2].iov_len = 16;
+            sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
+
+            let len1 = self.events.iter().map(|el| el.wire_len()).sum::<usize>();
+            let mut buf1 = vec![0u8; len1];
+            let mut offset1 = 0usize;
+            for el in self.events {
+                offset1 += el.serialize(&mut buf1[offset1..]);
+            }
+            sections[4].iov_base = buf1.as_ptr() as *mut _;
+            sections[4].iov_len = buf1.len();
+            sections[5].iov_len = base::align_pad(sections[4].iov_len, 4);
+
+            sections[6].iov_base = self.classes.as_ptr() as *mut _;
+            sections[6].iov_len = self.classes.len() * std::mem::size_of::<EventClass>();
+            sections[7].iov_len = base::align_pad(sections[6].iov_len, 4);
+
+            let flags = if checked { 1 } else { 0 };
+
+            xcb_send_request64(
+                c.get_raw_conn(),
+                flags,
+                sections.as_mut_ptr().add(2),
+                &mut protocol_request as *mut _,
+            )
+        }
+    }
+}
+
+impl<'a> base::Request for SendExtensionEvent<'a> {
+    type Cookie = base::VoidCookie;
+    const IS_VOID: bool = true;
+}
+
+impl<'a> base::RequestWithoutReply for SendExtensionEvent<'a> {}
```