### PR TITLE
Fix switch mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ conn.send_request(&x::CreateWindow {
     visual: screen.root_visual(),
     value_list: &[
         x::Cw::BackPixel(screen.white_pixel()),
-        x::Cw::EventMask((x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS).bits()),
+        x::Cw::EventMask(x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS),
     ],
 });
 ```

--- a/examples/basic_window.rs
+++ b/examples/basic_window.rs
@@ -25,7 +25,7 @@ fn main() -> xcb::Result<()> {
         visual: screen.root_visual(),
         value_list: &[
             x::Cw::BackPixel(screen.white_pixel()),
-            x::Cw::EventMask((x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS).bits()),
+            x::Cw::EventMask(x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS),
         ],
     });
 

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -80,7 +80,7 @@ fn main() -> xcb::Result<()> {
         visual: screen.root_visual(),
         value_list: &[
             x::Cw::BackPixel(screen.white_pixel()),
-            x::Cw::EventMask((x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS).bits()),
+            x::Cw::EventMask(x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS),
         ],
     });
 

--- a/examples/opengl_window.rs
+++ b/examples/opengl_window.rs
@@ -168,7 +168,7 @@ fn main() -> xcb::Result<()> {
         visual: vi.visualid as u32,
         value_list: &[
             x::Cw::BackPixel(screen.white_pixel()),
-            x::Cw::EventMask((x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS).bits()),
+            x::Cw::EventMask(x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS),
             x::Cw::Colormap(cmap),
         ],
     });

--- a/src/base.rs
+++ b/src/base.rs
@@ -1293,7 +1293,7 @@ impl Connection {
     ///         visual: screen.root_visual(),
     ///         value_list: &[
     ///             x::Cw::BackPixel(screen.white_pixel()),
-    ///             x::Cw::EventMask((x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS).bits()),
+    ///             x::Cw::EventMask(x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS),
     ///         ],
     ///     });
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //!         // this list must be in same order than `Cw` enum order
 //!         value_list: &[
 //!             x::Cw::BackPixel(screen.white_pixel()),
-//!             x::Cw::EventMask((x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS).bits())
+//!             x::Cw::EventMask(x::EventMask::EXPOSURE | x::EventMask::KEY_PRESS)
 //!         ],
 //!     });
 //!     // We now check if the window creation worked.

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
 use crate::base::{self, Wired};
-use crate::x::{Cw, Depth, DepthBuf, VisualClass, Visualtype};
+use crate::x;
 
 fn visual_data(bits_per_rgb_value: u8) -> Vec<u8> {
     vec![
@@ -54,10 +54,10 @@ fn depth_data(visual_bprv: &[u8], extra_garbage: usize) -> Vec<u8> {
 fn test_fixbuf_from_data() {
     let data = visual_data(24);
 
-    let vt = unsafe { Visualtype::from_data(&data) };
+    let vt = unsafe { x::Visualtype::from_data(&data) };
 
     assert_eq!(vt.visual_id(), 0x20304050);
-    assert_eq!(vt.class(), VisualClass::PseudoColor);
+    assert_eq!(vt.class(), x::VisualClass::PseudoColor);
     assert_eq!(vt.bits_per_rgb_value(), 24);
     assert_eq!(vt.colormap_entries(), 0x4050);
     assert_eq!(vt.red_mask(), 0x000000ff);
@@ -71,15 +71,15 @@ fn test_dynbuf_from_data() {
     let mut data = depth_data(&[32, 24], 4);
 
     assert_eq!(data.len(), 60);
-    assert_eq!(unsafe { Depth::compute_wire_len(data.as_ptr(), ()) }, 56);
+    assert_eq!(unsafe { x::Depth::compute_wire_len(data.as_ptr(), ()) }, 56);
     {
-        let depth = unsafe { Depth::from_data(&data[0..56]) };
+        let depth = unsafe { x::Depth::from_data(&data[0..56]) };
         assert_eq!(depth.depth(), 16);
         let visuals = depth.visuals();
         assert_eq!(visuals.len(), 2);
         let vt = visuals[0];
         assert_eq!(vt.visual_id(), 0x20304050);
-        assert_eq!(vt.class(), VisualClass::PseudoColor);
+        assert_eq!(vt.class(), x::VisualClass::PseudoColor);
         assert_eq!(vt.bits_per_rgb_value(), 32);
         assert_eq!(vt.colormap_entries(), 0x4050);
         assert_eq!(vt.red_mask(), 0x000000ff);
@@ -87,7 +87,7 @@ fn test_dynbuf_from_data() {
         assert_eq!(vt.blue_mask(), 0x00ff0000);
         let vt = visuals[1];
         assert_eq!(vt.visual_id(), 0x20304050);
-        assert_eq!(vt.class(), VisualClass::PseudoColor);
+        assert_eq!(vt.class(), x::VisualClass::PseudoColor);
         assert_eq!(vt.bits_per_rgb_value(), 24);
         assert_eq!(vt.colormap_entries(), 0x4050);
         assert_eq!(vt.red_mask(), 0x000000ff);
@@ -101,13 +101,13 @@ fn test_dynbuf_from_data() {
     data.pop();
     data.pop();
 
-    let depth = unsafe { DepthBuf::from_data(data) };
+    let depth = unsafe { x::DepthBuf::from_data(data) };
     assert_eq!(depth.depth(), 16);
     let visuals = depth.visuals();
     assert_eq!(visuals.len(), 2);
     let vt = visuals[0];
     assert_eq!(vt.visual_id(), 0x20304050);
-    assert_eq!(vt.class(), VisualClass::PseudoColor);
+    assert_eq!(vt.class(), x::VisualClass::PseudoColor);
     assert_eq!(vt.bits_per_rgb_value(), 32);
     assert_eq!(vt.colormap_entries(), 0x4050);
     assert_eq!(vt.red_mask(), 0x000000ff);
@@ -115,7 +115,7 @@ fn test_dynbuf_from_data() {
     assert_eq!(vt.blue_mask(), 0x00ff0000);
     let vt = visuals[1];
     assert_eq!(vt.visual_id(), 0x20304050);
-    assert_eq!(vt.class(), VisualClass::PseudoColor);
+    assert_eq!(vt.class(), x::VisualClass::PseudoColor);
     assert_eq!(vt.bits_per_rgb_value(), 24);
     assert_eq!(vt.colormap_entries(), 0x4050);
     assert_eq!(vt.red_mask(), 0x000000ff);
@@ -128,32 +128,32 @@ fn test_dynbuf_from_data() {
 #[cfg(target_endian = "little")]
 fn test_dynbuf_from_data_panic() {
     let data = depth_data(&[32, 24], 4);
-    unsafe { DepthBuf::from_data(data) };
+    unsafe { x::DepthBuf::from_data(data) };
 }
 
 #[test]
 fn test_cw_is_sorted_distinct() {
-    assert!(Cw::is_sorted_distinct(&[
-        Cw::BackPixel(4),
-        Cw::BitGravity(4),
-        Cw::WinGravity(4),
+    assert!(x::Cw::is_sorted_distinct(&[
+        x::Cw::BackPixel(4),
+        x::Cw::BitGravity(x::Gravity::West),
+        x::Cw::WinGravity(x::Gravity::West),
     ]));
 
-    assert!(!Cw::is_sorted_distinct(&[
-        Cw::BackPixel(4),
-        Cw::WinGravity(4),
-        Cw::BitGravity(4),
+    assert!(!x::Cw::is_sorted_distinct(&[
+        x::Cw::BackPixel(4),
+        x::Cw::WinGravity(x::Gravity::West),
+        x::Cw::BitGravity(x::Gravity::West),
     ]));
 
-    assert!(!Cw::is_sorted_distinct(&[
-        Cw::BackPixel(4),
-        Cw::BitGravity(4),
-        Cw::BitGravity(4),
+    assert!(!x::Cw::is_sorted_distinct(&[
+        x::Cw::BackPixel(4),
+        x::Cw::BitGravity(x::Gravity::West),
+        x::Cw::BitGravity(x::Gravity::West),
     ]));
 
-    assert!(!Cw::is_sorted_distinct(&[
-        Cw::BackPixel(4),
-        Cw::BitGravity(4),
-        Cw::BitGravity(5),
+    assert!(!x::Cw::is_sorted_distinct(&[
+        x::Cw::BackPixel(4),
+        x::Cw::BitGravity(x::Gravity::West),
+        x::Cw::BitGravity(x::Gravity::Center),
     ]));
 }


### PR DESCRIPTION
Fix the use of mask and enums in switch members.

The generated code diff:
```diff
diff -ur gen/previous/render.rs gen/current/render.rs
--- gen/previous/render.rs	2021-11-18 22:01:37.533323442 +0100
+++ gen/current/render.rs	2021-11-18 23:09:22.753332735 +0100
@@ -1505,7 +1505,7 @@

 #[derive(Clone, Debug)]
 pub enum Cp {
-    Repeat(u32),
+    Repeat(Repeat),
     AlphaMap(Picture),
     AlphaXOrigin(i32),
     AlphaYOrigin(i32),
@@ -1513,9 +1513,9 @@
     ClipYOrigin(i32),
     ClipMask(xproto::Pixmap),
     GraphicsExposure(u32),
-    SubwindowMode(u32),
-    PolyEdge(u32),
-    PolyMode(u32),
+    SubwindowMode(xproto::SubwindowMode),
+    PolyEdge(PolyEdge),
+    PolyMode(PolyMode),
     Dither(xproto::Atom),
     ComponentAlpha(u32),
 }
@@ -1716,7 +1716,8 @@
         for el in self.iter() {
             match el {
                 Cp::Repeat(repeat) => {
-                    offset += repeat.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*repeat) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cp::AlphaMap(alphamap) => {
                     offset += alphamap.serialize(&mut wire_buf[offset..]);
@@ -1740,13 +1741,16 @@
                     offset += graphicsexposure.serialize(&mut wire_buf[offset..]);
                 }
                 Cp::SubwindowMode(subwindowmode) => {
-                    offset += subwindowmode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*subwindowmode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cp::PolyEdge(polyedge) => {
-                    offset += polyedge.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*polyedge) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cp::PolyMode(polymode) => {
-                    offset += polymode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*polymode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cp::Dither(dither) => {
                     offset += dither.serialize(&mut wire_buf[offset..]);
diff -ur gen/previous/sync.rs gen/current/sync.rs
--- gen/previous/sync.rs	2021-11-18 22:01:38.129990104 +0100
+++ gen/current/sync.rs	2021-11-18 23:09:23.333332730 +0100
@@ -1152,9 +1152,9 @@
 #[derive(Clone, Debug)]
 pub enum Ca {
     Counter(Counter),
-    ValueType(u32),
+    ValueType(Valuetype),
     Value(Int64),
-    TestType(u32),
+    TestType(Testtype),
     Delta(Int64),
     Events(u32),
 }
@@ -1281,13 +1281,15 @@
                     offset += counter.serialize(&mut wire_buf[offset..]);
                 }
                 Ca::ValueType(value_type) => {
-                    offset += value_type.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*value_type) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Ca::Value(value) => {
                     offset += value.serialize(&mut wire_buf[offset..]);
                 }
                 Ca::TestType(test_type) => {
-                    offset += test_type.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*test_type) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Ca::Delta(delta) => {
                     offset += delta.serialize(&mut wire_buf[offset..]);
diff -ur gen/previous/xinput.rs gen/current/xinput.rs
--- gen/previous/xinput.rs	2021-11-18 22:01:39.136656761 +0100
+++ gen/current/xinput.rs	2021-11-18 23:09:24.306666055 +0100
@@ -5623,7 +5623,7 @@
     Button(u16),
     Valuator {
         axes_len: u8,
-        mode: u8,
+        mode: ValuatorMode,
         motion_size: u32,
         axes: Vec<AxisInfo>,
     },
@@ -5735,7 +5735,8 @@
                 axes,
             } => {
                 offset += axes_len.serialize(&mut wire_buf[offset..]);
-                offset += mode.serialize(&mut wire_buf[offset..]);
+                offset += (unsafe { std::mem::transmute::<_, u32>(*mode) } as u8)
+                    .serialize(&mut wire_buf[offset..]);
                 offset += motion_size.serialize(&mut wire_buf[offset..]);
                 for el in axes {
                     offset += el.serialize(&mut wire_buf[offset..]);
@@ -9056,7 +9057,7 @@
     },
     Valuator {
         num_valuators: u8,
-        mode: u8,
+        mode: ValuatorStateModeMask,
         valuators: Vec<i32>,
     },
 }
@@ -9170,7 +9171,7 @@
                 valuators,
             } => {
                 offset += num_valuators.serialize(&mut wire_buf[offset..]);
-                offset += mode.serialize(&mut wire_buf[offset..]);
+                offset += (mode.bits() as u8).serialize(&mut wire_buf[offset..]);
                 for el in valuators {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
@@ -11961,7 +11962,7 @@
     },
     RemoveMaster {
         deviceid: DeviceId,
-        return_mode: u8,
+        return_mode: ChangeMode,
         return_pointer: DeviceId,
         return_keyboard: DeviceId,
     },
@@ -12105,7 +12106,8 @@
                 return_keyboard,
             } => {
                 offset += deviceid.serialize(&mut wire_buf[offset..]);
-                offset += return_mode.serialize(&mut wire_buf[offset..]);
+                offset += (unsafe { std::mem::transmute::<_, u32>(*return_mode) } as u8)
+                    .serialize(&mut wire_buf[offset..]);
                 offset += 1;
                 offset += return_pointer.serialize(&mut wire_buf[offset..]);
                 offset += return_keyboard.serialize(&mut wire_buf[offset..]);
@@ -13254,16 +13256,16 @@
         max: Fp3232,
         value: Fp3232,
         resolution: u32,
-        mode: u8,
+        mode: ValuatorMode,
     },
     Scroll {
         number: u16,
-        scroll_type: u16,
-        flags: u32,
+        scroll_type: ScrollType,
+        flags: ScrollFlags,
         increment: Fp3232,
     },
     Touch {
-        mode: u8,
+        mode: TouchMode,
         num_touches: u8,
     },
 }
@@ -13450,7 +13452,8 @@
                 offset += max.serialize(&mut wire_buf[offset..]);
                 offset += value.serialize(&mut wire_buf[offset..]);
                 offset += resolution.serialize(&mut wire_buf[offset..]);
-                offset += mode.serialize(&mut wire_buf[offset..]);
+                offset += (unsafe { std::mem::transmute::<_, u32>(*mode) } as u8)
+                    .serialize(&mut wire_buf[offset..]);
                 offset += 3;
             }
             DeviceClassData::Scroll {
@@ -13460,13 +13463,15 @@
                 increment,
             } => {
                 offset += number.serialize(&mut wire_buf[offset..]);
-                offset += scroll_type.serialize(&mut wire_buf[offset..]);
+                offset += (unsafe { std::mem::transmute::<_, u32>(*scroll_type) } as u16)
+                    .serialize(&mut wire_buf[offset..]);
                 offset += 2;
-                offset += flags.serialize(&mut wire_buf[offset..]);
+                offset += (flags.bits() as u32).serialize(&mut wire_buf[offset..]);
                 offset += increment.serialize(&mut wire_buf[offset..]);
             }
             DeviceClassData::Touch { mode, num_touches } => {
-                offset += mode.serialize(&mut wire_buf[offset..]);
+                offset += (unsafe { std::mem::transmute::<_, u32>(*mode) } as u8)
+                    .serialize(&mut wire_buf[offset..]);
                 offset += num_touches.serialize(&mut wire_buf[offset..]);
             }
         }
diff -ur gen/previous/xkb.rs gen/current/xkb.rs
--- gen/previous/xkb.rs	2021-11-18 22:01:39.396656758 +0100
+++ gen/current/xkb.rs	2021-11-18 23:09:24.559999386 +0100
@@ -7177,16 +7177,16 @@
 #[derive(Clone, Debug)]
 pub enum SelectEventsDetails {
     NewKeyboardNotify {
-        affect_new_keyboard: u16,
-        new_keyboard_details: u16,
+        affect_new_keyboard: NknDetail,
+        new_keyboard_details: NknDetail,
     },
     StateNotify {
-        affect_state: u16,
-        state_details: u16,
+        affect_state: StatePart,
+        state_details: StatePart,
     },
     ControlsNotify {
-        affect_ctrls: u32,
-        ctrl_details: u32,
+        affect_ctrls: Control,
+        ctrl_details: Control,
     },
     IndicatorStateNotify {
         affect_indicator_state: u32,
@@ -7197,12 +7197,12 @@
         indicator_map_details: u32,
     },
     NamesNotify {
-        affect_names: u16,
-        names_details: u16,
+        affect_names: NameDetail,
+        names_details: NameDetail,
     },
     CompatMapNotify {
-        affect_compat: u8,
-        compat_details: u8,
+        affect_compat: CmDetail,
+        compat_details: CmDetail,
     },
     BellNotify {
         affect_bell: u8,
@@ -7213,12 +7213,12 @@
         msg_details: u8,
     },
     AccessXNotify {
-        affect_access_x: u16,
-        access_x_details: u16,
+        affect_access_x: AxnDetail,
+        access_x_details: AxnDetail,
     },
     ExtensionDeviceNotify {
-        affect_ext_dev: u16,
-        extdev_details: u16,
+        affect_ext_dev: XiFeature,
+        extdev_details: XiFeature,
     },
 }

@@ -7469,22 +7469,24 @@
                     affect_new_keyboard,
                     new_keyboard_details,
                 } => {
-                    offset += affect_new_keyboard.serialize(&mut wire_buf[offset..]);
-                    offset += new_keyboard_details.serialize(&mut wire_buf[offset..]);
+                    offset +=
+                        (affect_new_keyboard.bits() as u16).serialize(&mut wire_buf[offset..]);
+                    offset +=
+                        (new_keyboard_details.bits() as u16).serialize(&mut wire_buf[offset..]);
                 }
                 SelectEventsDetails::StateNotify {
                     affect_state,
                     state_details,
                 } => {
-                    offset += affect_state.serialize(&mut wire_buf[offset..]);
-                    offset += state_details.serialize(&mut wire_buf[offset..]);
+                    offset += (affect_state.bits() as u16).serialize(&mut wire_buf[offset..]);
+                    offset += (state_details.bits() as u16).serialize(&mut wire_buf[offset..]);
                 }
                 SelectEventsDetails::ControlsNotify {
                     affect_ctrls,
                     ctrl_details,
                 } => {
-                    offset += affect_ctrls.serialize(&mut wire_buf[offset..]);
-                    offset += ctrl_details.serialize(&mut wire_buf[offset..]);
+                    offset += (affect_ctrls.bits() as u32).serialize(&mut wire_buf[offset..]);
+                    offset += (ctrl_details.bits() as u32).serialize(&mut wire_buf[offset..]);
                 }
                 SelectEventsDetails::IndicatorStateNotify {
                     affect_indicator_state,
@@ -7504,15 +7506,15 @@
                     affect_names,
                     names_details,
                 } => {
-                    offset += affect_names.serialize(&mut wire_buf[offset..]);
-                    offset += names_details.serialize(&mut wire_buf[offset..]);
+                    offset += (affect_names.bits() as u16).serialize(&mut wire_buf[offset..]);
+                    offset += (names_details.bits() as u16).serialize(&mut wire_buf[offset..]);
                 }
                 SelectEventsDetails::CompatMapNotify {
                     affect_compat,
                     compat_details,
                 } => {
-                    offset += affect_compat.serialize(&mut wire_buf[offset..]);
-                    offset += compat_details.serialize(&mut wire_buf[offset..]);
+                    offset += (affect_compat.bits() as u8).serialize(&mut wire_buf[offset..]);
+                    offset += (compat_details.bits() as u8).serialize(&mut wire_buf[offset..]);
                 }
                 SelectEventsDetails::BellNotify {
                     affect_bell,
@@ -7532,15 +7534,15 @@
                     affect_access_x,
                     access_x_details,
                 } => {
-                    offset += affect_access_x.serialize(&mut wire_buf[offset..]);
-                    offset += access_x_details.serialize(&mut wire_buf[offset..]);
+                    offset += (affect_access_x.bits() as u16).serialize(&mut wire_buf[offset..]);
+                    offset += (access_x_details.bits() as u16).serialize(&mut wire_buf[offset..]);
                 }
                 SelectEventsDetails::ExtensionDeviceNotify {
                     affect_ext_dev,
                     extdev_details,
                 } => {
-                    offset += affect_ext_dev.serialize(&mut wire_buf[offset..]);
-                    offset += extdev_details.serialize(&mut wire_buf[offset..]);
+                    offset += (affect_ext_dev.bits() as u16).serialize(&mut wire_buf[offset..]);
+                    offset += (extdev_details.bits() as u16).serialize(&mut wire_buf[offset..]);
                 }
             }
         }
@@ -9449,7 +9451,7 @@
         getmap_length: u32,
         type_min_key_code: xproto::Keycode,
         type_max_key_code: xproto::Keycode,
-        present: u16,
+        present: MapPart,
         first_type: u8,
         n_types: u8,
         total_types: u8,
@@ -9471,7 +9473,7 @@
         first_v_mod_map_key: xproto::Keycode,
         n_v_mod_map_keys: u8,
         total_v_mod_map_keys: u8,
-        virtual_mods: u16,
+        virtual_mods: VMod,
         map: Vec<GetKbdByNameReplyRepliesMap>,
     },
     CompatMap {
@@ -9479,7 +9481,7 @@
         compat_device_id: u8,
         compatmap_sequence: u16,
         compatmap_length: u32,
-        groups_rtrn: u8,
+        groups_rtrn: SetOfGroup,
         first_si_rtrn: u16,
         n_si_rtrn: u16,
         n_total_si: u16,
@@ -9501,12 +9503,12 @@
         key_device_id: u8,
         keyname_sequence: u16,
         keyname_length: u32,
-        which: u32,
+        which: NameDetail,
         key_min_key_code: xproto::Keycode,
         key_max_key_code: xproto::Keycode,
         n_types: u8,
-        group_names: u8,
-        virtual_mods: u16,
+        group_names: SetOfGroup,
+        virtual_mods: VMod,
         first_key: xproto::Keycode,
         n_keys: u8,
         indicators: u32,
@@ -10083,7 +10085,7 @@
                     offset += 2;
                     offset += type_min_key_code.serialize(&mut wire_buf[offset..]);
                     offset += type_max_key_code.serialize(&mut wire_buf[offset..]);
-                    offset += present.serialize(&mut wire_buf[offset..]);
+                    offset += (present.bits() as u16).serialize(&mut wire_buf[offset..]);
                     offset += first_type.serialize(&mut wire_buf[offset..]);
                     offset += n_types.serialize(&mut wire_buf[offset..]);
                     offset += total_types.serialize(&mut wire_buf[offset..]);
@@ -10106,7 +10108,7 @@
                     offset += n_v_mod_map_keys.serialize(&mut wire_buf[offset..]);
                     offset += total_v_mod_map_keys.serialize(&mut wire_buf[offset..]);
                     offset += 1;
-                    offset += virtual_mods.serialize(&mut wire_buf[offset..]);
+                    offset += (virtual_mods.bits() as u16).serialize(&mut wire_buf[offset..]);
                     offset += map.as_slice().serialize(&mut wire_buf[offset..]);
                 }
                 GetKbdByNameReplyReplies::CompatMap {
@@ -10125,7 +10127,7 @@
                     offset += compat_device_id.serialize(&mut wire_buf[offset..]);
                     offset += compatmap_sequence.serialize(&mut wire_buf[offset..]);
                     offset += compatmap_length.serialize(&mut wire_buf[offset..]);
-                    offset += groups_rtrn.serialize(&mut wire_buf[offset..]);
+                    offset += (groups_rtrn.bits() as u8).serialize(&mut wire_buf[offset..]);
                     offset += 1;
                     offset += first_si_rtrn.serialize(&mut wire_buf[offset..]);
                     offset += n_si_rtrn.serialize(&mut wire_buf[offset..]);
@@ -10183,12 +10185,12 @@
                     offset += key_device_id.serialize(&mut wire_buf[offset..]);
                     offset += keyname_sequence.serialize(&mut wire_buf[offset..]);
                     offset += keyname_length.serialize(&mut wire_buf[offset..]);
-                    offset += which.serialize(&mut wire_buf[offset..]);
+                    offset += (which.bits() as u32).serialize(&mut wire_buf[offset..]);
                     offset += key_min_key_code.serialize(&mut wire_buf[offset..]);
                     offset += key_max_key_code.serialize(&mut wire_buf[offset..]);
                     offset += n_types.serialize(&mut wire_buf[offset..]);
-                    offset += group_names.serialize(&mut wire_buf[offset..]);
-                    offset += virtual_mods.serialize(&mut wire_buf[offset..]);
+                    offset += (group_names.bits() as u8).serialize(&mut wire_buf[offset..]);
+                    offset += (virtual_mods.bits() as u16).serialize(&mut wire_buf[offset..]);
                     offset += first_key.serialize(&mut wire_buf[offset..]);
                     offset += n_keys.serialize(&mut wire_buf[offset..]);
                     offset += indicators.serialize(&mut wire_buf[offset..]);
diff -ur gen/previous/xproto.rs gen/current/xproto.rs
--- gen/previous/xproto.rs	2021-11-18 22:01:39.806656755 +0100
+++ gen/current/xproto.rs	2021-11-18 23:09:25.023332714 +0100
@@ -8828,15 +8828,15 @@
     BackPixel(u32),
     BorderPixmap(Pixmap),
     BorderPixel(u32),
-    BitGravity(u32),
-    WinGravity(u32),
-    BackingStore(u32),
+    BitGravity(Gravity),
+    WinGravity(Gravity),
+    BackingStore(BackingStore),
     BackingPlanes(u32),
     BackingPixel(u32),
     OverrideRedirect(bool),
     SaveUnder(bool),
-    EventMask(u32),
-    DontPropagate(u32),
+    EventMask(EventMask),
+    DontPropagate(EventMask),
     Colormap(Colormap),
     Cursor(Cursor),
 }
@@ -9071,13 +9071,16 @@
                     offset += border_pixel.serialize(&mut wire_buf[offset..]);
                 }
                 Cw::BitGravity(bit_gravity) => {
-                    offset += bit_gravity.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*bit_gravity) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cw::WinGravity(win_gravity) => {
-                    offset += win_gravity.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*win_gravity) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cw::BackingStore(backing_store) => {
-                    offset += backing_store.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*backing_store) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Cw::BackingPlanes(backing_planes) => {
                     offset += backing_planes.serialize(&mut wire_buf[offset..]);
@@ -9094,10 +9097,11 @@
                     offset += save_under.serialize(&mut wire_buf[offset..]);
                 }
                 Cw::EventMask(event_mask) => {
-                    offset += event_mask.serialize(&mut wire_buf[offset..]);
+                    offset += (event_mask.bits() as u32).serialize(&mut wire_buf[offset..]);
                 }
                 Cw::DontPropagate(do_not_propogate_mask) => {
-                    offset += do_not_propogate_mask.serialize(&mut wire_buf[offset..]);
+                    offset +=
+                        (do_not_propogate_mask.bits() as u32).serialize(&mut wire_buf[offset..]);
                 }
                 Cw::Colormap(colormap) => {
                     offset += colormap.serialize(&mut wire_buf[offset..]);
@@ -9124,7 +9128,7 @@
     Height(u32),
     BorderWidth(u32),
     Sibling(Window),
-    StackMode(u32),
+    StackMode(StackMode),
 }

 impl ConfigWindow {
@@ -9275,7 +9279,8 @@
                     offset += sibling.serialize(&mut wire_buf[offset..]);
                 }
                 ConfigWindow::StackMode(stack_mode) => {
-                    offset += stack_mode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*stack_mode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
             }
         }
@@ -9290,29 +9295,29 @@

 #[derive(Clone, Debug)]
 pub enum Gc {
-    Function(u32),
+    Function(Gx),
     PlaneMask(u32),
     Foreground(u32),
     Background(u32),
     LineWidth(u32),
-    LineStyle(u32),
-    CapStyle(u32),
-    JoinStyle(u32),
-    FillStyle(u32),
-    FillRule(u32),
+    LineStyle(LineStyle),
+    CapStyle(CapStyle),
+    JoinStyle(JoinStyle),
+    FillStyle(FillStyle),
+    FillRule(FillRule),
     Tile(Pixmap),
     Stipple(Pixmap),
     TileStippleOriginX(i32),
     TileStippleOriginY(i32),
     Font(Font),
-    SubwindowMode(u32),
+    SubwindowMode(SubwindowMode),
     GraphicsExposures(bool),
     ClipOriginX(i32),
     ClipOriginY(i32),
     ClipMask(Pixmap),
     DashOffset(u32),
     DashList(u32),
-    ArcMode(u32),
+    ArcMode(ArcMode),
 }

 impl Gc {
@@ -9621,7 +9626,8 @@
         for el in self.iter() {
             match el {
                 Gc::Function(function) => {
-                    offset += function.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*function) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::PlaneMask(plane_mask) => {
                     offset += plane_mask.serialize(&mut wire_buf[offset..]);
@@ -9636,19 +9642,24 @@
                     offset += line_width.serialize(&mut wire_buf[offset..]);
                 }
                 Gc::LineStyle(line_style) => {
-                    offset += line_style.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*line_style) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::CapStyle(cap_style) => {
-                    offset += cap_style.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*cap_style) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::JoinStyle(join_style) => {
-                    offset += join_style.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*join_style) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::FillStyle(fill_style) => {
-                    offset += fill_style.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*fill_style) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::FillRule(fill_rule) => {
-                    offset += fill_rule.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*fill_rule) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::Tile(tile) => {
                     offset += tile.serialize(&mut wire_buf[offset..]);
@@ -9666,7 +9677,8 @@
                     offset += font.serialize(&mut wire_buf[offset..]);
                 }
                 Gc::SubwindowMode(subwindow_mode) => {
-                    offset += subwindow_mode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*subwindow_mode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Gc::GraphicsExposures(graphics_exposures) => {
                     let graphics_exposures: u32 = if *graphics_exposures { 1 } else { 0 };
@@ -9688,7 +9700,8 @@
                     offset += dashes.serialize(&mut wire_buf[offset..]);
                 }
                 Gc::ArcMode(arc_mode) => {
-                    offset += arc_mode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*arc_mode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
             }
         }
@@ -9708,9 +9721,9 @@
     BellPitch(i32),
     BellDuration(i32),
     Led(u32),
-    LedMode(u32),
+    LedMode(LedMode),
     Key(Keycode32),
-    AutoRepeatMode(u32),
+    AutoRepeatMode(AutoRepeatMode),
 }

 impl Kb {
@@ -9869,13 +9882,15 @@
                     offset += led.serialize(&mut wire_buf[offset..]);
                 }
                 Kb::LedMode(led_mode) => {
-                    offset += led_mode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*led_mode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
                 Kb::Key(key) => {
                     offset += key.serialize(&mut wire_buf[offset..]);
                 }
                 Kb::AutoRepeatMode(auto_repeat_mode) => {
-                    offset += auto_repeat_mode.serialize(&mut wire_buf[offset..]);
+                    offset += (unsafe { std::mem::transmute::<_, u32>(*auto_repeat_mode) } as u32)
+                        .serialize(&mut wire_buf[offset..]);
                 }
             }
         }
```