### PR TITLE
fix xkb::String8

### DIFF
--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -697,9 +697,10 @@ impl CodeGen {
             | "FLOAT64" => { return; }
             _ => {}
         }
-        if new_typ == "BOOL32" {
-            return;
-        }
+        let old_typ = match new_typ {
+            "STRING8" => "CARD8",
+            _ => old_typ,
+        };
         let rs_typ = rust_type_name(new_typ);
         let (old_module, old_typ) = extract_module(old_typ);
         let old_typinfo = self.find_typinfo(old_module, old_typ);


### PR DESCRIPTION
`String8` was defined as `char`, but should be `u8`.
It misses probably opportunities to be treated as `&str`, but at least is correct regarding the protocol.

diff:
```diff
diff -ur gen/previous/xkb.rs gen/current/xkb.rs
--- gen/previous/xkb.rs	2021-11-21 11:45:35.676221006 +0100
+++ gen/current/xkb.rs	2021-11-21 21:53:20.273232063 +0100
@@ -5010,7 +5010,7 @@
     }
 }
 
-pub type String8 = char;
+pub type String8 = u8;
 
 pub struct Outline {
     data: [u8],
@@ -5359,57 +5359,13 @@
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
 pub struct Key {
-    data: [u8; 8],
-}
-
-#[allow(unused_parens)]
-impl Key {
-    pub(crate) unsafe fn from_data<D: AsRef<[u8]> + ?Sized>(data: &D) -> &Key {
-        debug_assert_eq!(data.as_ref().len(), 8);
-        &*(data.as_ref() as *const [u8] as *const Key)
-    }
-
-    fn wire_ptr(&self) -> *const u8 {
-        self.data.as_ptr()
-    }
-
-    fn wire_len(&self) -> usize {
-        self.data.len()
-    }
-
-    pub fn name(&self) -> &[String8; 4] {
-        unsafe {
-            let offset = 0usize;
-            let ptr = self.wire_ptr().add(offset) as *const [String8; 4];
-            &*ptr
-        }
-    }
-
-    pub fn gap(&self) -> i16 {
-        unsafe {
-            let offset = 4usize;
-            let ptr = self.wire_ptr().add(offset) as *const i16;
-            *ptr
-        }
-    }
-
-    pub fn shape_ndx(&self) -> u8 {
-        unsafe {
-            let offset = 6usize;
-            let ptr = self.wire_ptr().add(offset) as *const u8;
-            *ptr
-        }
-    }
-
-    pub fn color_ndx(&self) -> u8 {
-        unsafe {
-            let offset = 7usize;
-            let ptr = self.wire_ptr().add(offset) as *const u8;
-            *ptr
-        }
-    }
+    pub name: [String8; 4],
+    pub gap: i16,
+    pub shape_ndx: u8,
+    pub color_ndx: u8,
 }
 
 #[test]
@@ -5428,57 +5384,17 @@
     }
 
     fn serialize(&self, wire_buf: &mut [u8]) -> usize {
-        wire_buf.copy_from_slice(&self.data);
-        self.data.len()
-    }
-}
-
-impl std::fmt::Debug for Key {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Key")
-            .field("name", &self.name())
-            .field("gap", &self.gap())
-            .field("shape_ndx", &self.shape_ndx())
-            .field("color_ndx", &self.color_ndx())
-            .finish()
+        let me = unsafe { std::slice::from_raw_parts(self as *const Key as _, 8) };
+        wire_buf.copy_from_slice(me);
+        8
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
 pub struct OverlayKey {
-    data: [u8; 8],
-}
-
-#[allow(unused_parens)]
-impl OverlayKey {
-    pub(crate) unsafe fn from_data<D: AsRef<[u8]> + ?Sized>(data: &D) -> &OverlayKey {
-        debug_assert_eq!(data.as_ref().len(), 8);
-        &*(data.as_ref() as *const [u8] as *const OverlayKey)
-    }
-
-    fn wire_ptr(&self) -> *const u8 {
-        self.data.as_ptr()
-    }
-
-    fn wire_len(&self) -> usize {
-        self.data.len()
-    }
-
-    pub fn over(&self) -> &[String8; 4] {
-        unsafe {
-            let offset = 0usize;
-            let ptr = self.wire_ptr().add(offset) as *const [String8; 4];
-            &*ptr
-        }
-    }
-
-    pub fn under(&self) -> &[String8; 4] {
-        unsafe {
-            let offset = 4usize;
-            let ptr = self.wire_ptr().add(offset) as *const [String8; 4];
-            &*ptr
-        }
-    }
+    pub over: [String8; 4],
+    pub under: [String8; 4],
 }
 
 #[test]
@@ -5497,17 +5413,9 @@
     }
 
     fn serialize(&self, wire_buf: &mut [u8]) -> usize {
-        wire_buf.copy_from_slice(&self.data);
-        self.data.len()
-    }
-}
-
-impl std::fmt::Debug for OverlayKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OverlayKey")
-            .field("over", &self.over())
-            .field("under", &self.under())
-            .finish()
+        let me = unsafe { std::slice::from_raw_parts(self as *const OverlayKey as _, 8) };
+        wire_buf.copy_from_slice(me);
+        8
     }
 }
 
diff -ur gen/previous/xprint.rs gen/current/xprint.rs
--- gen/previous/xprint.rs	2021-11-21 11:45:35.946221003 +0100
+++ gen/current/xprint.rs	2021-11-21 21:53:20.416565395 +0100
@@ -509,7 +509,7 @@
     }
 }
 
-pub type String8 = char;
+pub type String8 = u8;
 
 pub struct Printer {
     data: [u8],
```