### PR TITLE
emit struct ctor

### DIFF
--- a/build/cg/request.rs
+++ b/build/cg/request.rs
@@ -891,45 +891,6 @@ impl CodeGen {
                         offset
                     )?;
 
-                    // if let Some(value) = fieldref_value {
-                    //     writeln!(
-                    //         out,
-                    //         "{}({} as {}).serialize(&mut buf{}[{} .. ]);",
-                    //         cg::ind(2),
-                    //         value,
-                    //         q_rs_typ,
-                    //         num,
-                    //         offset
-                    //     )?;
-                    // } else if (mask.is_some() || r#enum.is_some()) && rs_typ == "bool" {
-                    //     writeln!(
-                    //         out,
-                    //         "{}*(buf{}.as_mut_ptr().add({}) as *mut {}) = std::mem::transmute::<_, u32>(self.{}) != 0;",
-                    //         cg::ind(2), num, offset, q_rs_typ, name
-                    //     )?;
-                    // } else if mask.is_some() || r#enum.is_some() {
-                    //     writeln!(
-                    //         out,
-                    //         "{}*(buf{}.as_mut_ptr().add({}) as *mut {}) = std::mem::transmute::<_, u32>(self.{}) as {};",
-                    //         cg::ind(2), num, offset, q_rs_typ, name, q_rs_typ
-                    //     )?;
-                    // } else {
-                    //     let (ptr_typ, postfix) = if rs_typ == "SendEventDest" {
-                    //         ("u32", ".resource_id()")
-                    //     } else {
-                    //         (q_rs_typ.as_str(), "")
-                    //     };
-                    //     writeln!(
-                    //         out,
-                    //         "{}*(buf{}.as_mut_ptr().add({}) as *mut {}) = self.{}{};",
-                    //         cg::ind(2),
-                    //         num,
-                    //         offset,
-                    //         ptr_typ,
-                    //         name,
-                    //         postfix
-                    //     )?;
-                    // }
                     offset += sz;
                 }
                 Field::List {
@@ -1252,7 +1213,7 @@ enum SerializeSection<'a> {
 //    - a single fieldref
 //    - a fieldref multiplied by format divided by 8 (for properties only)
 // For other cases, we put the field as public paramater and require user to supply a value.
-fn request_fieldref_emitted(name: &str, fields: &[Field], has_prop_field: bool) -> bool {
+pub(super) fn request_fieldref_emitted(name: &str, fields: &[Field], has_prop_field: bool) -> bool {
     for f in fields {
         match f {
             Field::List {
@@ -1307,7 +1268,7 @@ fn is_prop_field_mult<'a>(name: &'a str, lhs: &Expr, rhs: &Expr) -> bool {
     true
 }
 
-fn fieldref_get_value(
+pub(super) fn fieldref_get_value(
     name: &str,
     fields: &[Field],
     has_prop_field: bool,

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1358,7 +1358,7 @@ impl CodeGen {
                         value_expr =
                             format!("(if {} {{ 1u{} }} else {{ 0u{} }})", name, 8 * sz, 8 * sz);
                     } else {
-                        value_expr = format!("{}", name);
+                        value_expr = name.to_string();
                     }
 
                     writeln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,7 @@ pub mod record {
     //!
     //! Accessible with the `record` cargo feature.
     #![allow(clippy::unit_arg)]
+    #![allow(clippy::too_many_arguments)]
     include!(concat!(env!("OUT_DIR"), "/record.rs"));
 }
 
@@ -528,6 +529,7 @@ pub mod xf86vidmode {
     //! The `XFree86-VidModeExtension` X extension.
     //!
     //! Accessible with the `xf86vidmode` cargo feature.
+    #![allow(clippy::too_many_arguments)]
     include!(concat!(env!("OUT_DIR"), "/xf86vidmode.rs"));
 }
 


### PR DESCRIPTION
extract of diff:
```diff
diff -ur gen/previous/dri2.rs gen/current/dri2.rs
--- gen/previous/dri2.rs	2021-11-21 22:18:25.789998318 +0100
+++ gen/current/dri2.rs	2021-11-21 22:51:13.183312952 +0100
@@ -421,6 +421,24 @@
         &*(data.as_ref() as *const [u8] as *const Dri2Buffer)
     }
 
+    /// Construct a new [Dri2Buffer].
+    #[allow(unused_assignments, unused_unsafe)]
+    pub fn new(attachment: Attachment, name: u32, pitch: u32, cpp: u32, flags: u32) -> Dri2Buffer {
+        unsafe {
+            let mut wire_buf = [0u8; 20];
+            let mut wire_off = 0usize;
+
+            wire_off +=
+                std::mem::transmute::<_, u32>(attachment).serialize(&mut wire_buf[wire_off..]);
+            wire_off += name.serialize(&mut wire_buf[wire_off..]);
+            wire_off += pitch.serialize(&mut wire_buf[wire_off..]);
+            wire_off += cpp.serialize(&mut wire_buf[wire_off..]);
+            wire_off += flags.serialize(&mut wire_buf[wire_off..]);
+
+            Dri2Buffer { data: wire_buf }
+        }
+    }
+
     fn wire_ptr(&self) -> *const u8 {
         self.data.as_ptr()
     }
@@ -516,6 +534,21 @@
         &*(data.as_ref() as *const [u8] as *const AttachFormat)
     }
 
+    /// Construct a new [AttachFormat].
+    #[allow(unused_assignments, unused_unsafe)]
+    pub fn new(attachment: Attachment, format: u32) -> AttachFormat {
+        unsafe {
+            let mut wire_buf = [0u8; 8];
+            let mut wire_off = 0usize;
+
+            wire_off +=
+                std::mem::transmute::<_, u32>(attachment).serialize(&mut wire_buf[wire_off..]);
+            wire_off += format.serialize(&mut wire_buf[wire_off..]);
+
+            AttachFormat { data: wire_buf }
+        }
+    }
+
     fn wire_ptr(&self) -> *const u8 {
         self.data.as_ptr()
     }
diff -ur gen/previous/randr.rs gen/current/randr.rs
--- gen/previous/randr.rs	2021-11-21 22:18:26.613331643 +0100
+++ gen/current/randr.rs	2021-11-21 22:51:15.023312935 +0100
@@ -1041,6 +1041,25 @@
         );
         RefreshRatesBuf { data }
     }
+
+    /// Construct a new [RefreshRatesBuf].
+    #[allow(unused_assignments, unused_unsafe)]
+    pub fn new(rates: &[u16]) -> RefreshRatesBuf {
+        unsafe {
+            let mut wire_sz = 0usize;
+            wire_sz += 2; // n_rates
+            wire_sz += rates.iter().map(|el| el.wire_len()).sum::<usize>();
+            let mut wire_buf = vec![0u8; wire_sz];
+            let mut wire_off = 0usize;
+
+            wire_off += (rates.len() as u16).serialize(&mut wire_buf[wire_off..]);
+            for el in rates {
+                wire_off += el.serialize(&mut wire_buf[wire_off..]);
+            }
+
+            RefreshRatesBuf { data: wire_buf }
+        }
+    }
 }
 
 impl std::ops::Deref for RefreshRatesBuf {
@@ -1246,6 +1265,38 @@
         &*(data.as_ref() as *const [u8] as *const CrtcChange)
     }
 
+    /// Construct a new [CrtcChange].
+    #[allow(unused_assignments, unused_unsafe)]
+    pub fn new(
+        timestamp: xproto::Timestamp,
+        window: xproto::Window,
+        crtc: Crtc,
+        mode: Mode,
+        rotation: Rotation,
+        x: i16,
+        y: i16,
+        width: u16,
+        height: u16,
+    ) -> CrtcChange {
+        unsafe {
+            let mut wire_buf = [0u8; 28];
+            let mut wire_off = 0usize;
+
+            wire_off += timestamp.serialize(&mut wire_buf[wire_off..]);
+            wire_off += window.serialize(&mut wire_buf[wire_off..]);
+            wire_off += crtc.serialize(&mut wire_buf[wire_off..]);
+            wire_off += mode.serialize(&mut wire_buf[wire_off..]);
+            wire_off += (rotation.bits() as u16).serialize(&mut wire_buf[wire_off..]);
+            wire_off += 2; // pad
+            wire_off += x.serialize(&mut wire_buf[wire_off..]);
+            wire_off += y.serialize(&mut wire_buf[wire_off..]);
+            wire_off += width.serialize(&mut wire_buf[wire_off..]);
+            wire_off += height.serialize(&mut wire_buf[wire_off..]);
+
+            CrtcChange { data: wire_buf }
+        }
+    }
+
     fn wire_ptr(&self) -> *const u8 {
         self.data.as_ptr()
     }
```