### PR TITLE
Switch acc debug

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -2097,17 +2097,6 @@ impl CodeGen {
                     doc,
                     ..
                 } => {
-                    if *is_mask {
-                        continue;
-                    }
-                    let params_expr = self.build_params_expr(
-                        Some(params_struct),
-                        module.as_ref().map(|s| s.as_str()),
-                        "self.",
-                        "()",
-                    );
-                    let switch_expr = self.build_rs_expr(expr, "self.", "()", fields);
-                    let offset_expr = self.build_rs_expr(wire_off, "self.", "()", fields);
                     if let Some(doc) = doc {
                         doc.emit(out, 1)?;
                     }
@@ -2123,6 +2112,45 @@ impl CodeGen {
                         name,
                         return_typ
                     )?;
+                    // must define all params locally as usize because build_params_expr
+                    // cannot know if a field is a mask or not
+                    for p in &params_struct.params {
+                        let mut caught = false;
+                        for f in fields {
+                            match f {
+                                Field::Field {
+                                    name,
+                                    mask: Some(_),
+                                    ..
+                                } if name == p => {
+                                    writeln!(
+                                        out,
+                                        "{}let {} = self.{}().bits();",
+                                        cg::ind(2),
+                                        name,
+                                        name
+                                    )?;
+                                    caught = true;
+                                    break;
+                                }
+                                Field::Field { name, .. } if name == p => {
+                                    writeln!(out, "{}let {} = self.{}();", cg::ind(2), name, name)?;
+                                    caught = true;
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                        assert!(caught);
+                    }
+                    let params_expr = self.build_params_expr(
+                        Some(params_struct),
+                        module.as_ref().map(|s| s.as_str()),
+                        "",
+                        "",
+                    );
+                    let switch_expr = self.build_rs_expr(expr, "self.", "()", fields);
+                    let offset_expr = self.build_rs_expr(wire_off, "self.", "()", fields);
                     writeln!(out, "{}let params = {};", cg::ind(2), params_expr)?;
                     writeln!(out, "{}let offset = {};", cg::ind(2), offset_expr)?;
                     writeln!(out, "{}let switch = {};", cg::ind(2), switch_expr)?;

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -2307,8 +2307,8 @@ impl CodeGen {
                 Field::List { .. } => {
                     // TODO
                 }
-                Field::Switch { .. } => {
-                    // TODO
+                Field::Switch { name, .. } => {
+                    writeln!(out, "{}.field(\"{}\", &self.{}())", cg::ind(3), name, name)?;
                 }
                 Field::Pad {
                     wire_sz: Expr::Value(sz),


### PR DESCRIPTION
diff:
```diff
diff -ur gen/previous/xinput.rs gen/current/xinput.rs
--- gen/previous/xinput.rs	2021-12-04 12:12:32.326912508 +0100
+++ gen/current/xinput.rs	2021-12-05 09:53:16.828439873 +0100
@@ -5928,8 +5928,9 @@
     }
 
     pub fn info(&self) -> InputInfoInfo {
+        let class_id = self.class_id();
         let params = InputInfoInfoParams {
-            class_id: self.class_id() as usize,
+            class_id: class_id as usize,
         };
         let offset = 2usize;
         let switch = (self.class_id() as usize);
@@ -6026,6 +6027,7 @@
         f.debug_struct("InputInfo")
             .field("class_id", &self.class_id())
             .field("len", &self.len())
+            .field("info", &self.info())
             .finish()
     }
 }
@@ -6035,6 +6037,7 @@
         f.debug_struct("InputInfoBuf")
             .field("class_id", &self.class_id())
             .field("len", &self.len())
+            .field("info", &self.info())
             .finish()
     }
 }
@@ -7884,8 +7887,9 @@
     }
 
     pub fn data(&self) -> FeedbackStateData {
+        let class_id = self.class_id();
         let params = FeedbackStateDataParams {
-            class_id: self.class_id() as usize,
+            class_id: class_id as usize,
         };
         let offset = 4usize;
         let switch = (self.class_id() as usize);
@@ -7990,6 +7994,7 @@
             .field("class_id", &self.class_id())
             .field("feedback_id", &self.feedback_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -8000,6 +8005,7 @@
             .field("class_id", &self.class_id())
             .field("feedback_id", &self.feedback_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -9317,8 +9323,9 @@
     }
 
     pub fn data(&self) -> FeedbackCtlData {
+        let class_id = self.class_id();
         let params = FeedbackCtlDataParams {
-            class_id: self.class_id() as usize,
+            class_id: class_id as usize,
         };
         let offset = 4usize;
         let switch = (self.class_id() as usize);
@@ -9420,6 +9427,7 @@
             .field("class_id", &self.class_id())
             .field("feedback_id", &self.feedback_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -9430,6 +9438,7 @@
             .field("class_id", &self.class_id())
             .field("feedback_id", &self.feedback_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -10145,8 +10154,9 @@
     }
 
     pub fn data(&self) -> InputStateData {
+        let class_id = self.class_id();
         let params = InputStateDataParams {
-            class_id: self.class_id() as usize,
+            class_id: class_id as usize,
         };
         let offset = 2usize;
         let switch = (self.class_id() as usize);
@@ -10243,6 +10253,7 @@
         f.debug_struct("InputState")
             .field("class_id", &self.class_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -10252,6 +10263,7 @@
         f.debug_struct("InputStateBuf")
             .field("class_id", &self.class_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -11459,8 +11471,9 @@
     }
 
     pub fn data(&self) -> DeviceStateData {
+        let control_id = self.control_id();
         let params = DeviceStateDataParams {
-            control_id: self.control_id() as usize,
+            control_id: control_id as usize,
         };
         let offset = 4usize;
         let switch = (self.control_id() as usize);
@@ -11557,6 +11570,7 @@
         f.debug_struct("DeviceState")
             .field("control_id", &self.control_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -11566,6 +11580,7 @@
         f.debug_struct("DeviceStateBuf")
             .field("control_id", &self.control_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -12702,8 +12717,9 @@
     }
 
     pub fn data(&self) -> DeviceCtlData {
+        let control_id = self.control_id();
         let params = DeviceCtlDataParams {
-            control_id: self.control_id() as usize,
+            control_id: control_id as usize,
         };
         let offset = 4usize;
         let switch = (self.control_id() as usize);
@@ -12800,6 +12816,7 @@
         f.debug_struct("DeviceCtl")
             .field("control_id", &self.control_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -12809,6 +12826,7 @@
         f.debug_struct("DeviceCtlBuf")
             .field("control_id", &self.control_id())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -13781,8 +13799,9 @@
     }
 
     pub fn data(&self) -> HierarchyChangeData {
+        let r#type = self.r#type();
         let params = HierarchyChangeDataParams {
-            r#type: self.r#type() as usize,
+            r#type: r#type as usize,
         };
         let offset = 4usize;
         let switch = (self.r#type() as usize);
@@ -13882,6 +13901,7 @@
         f.debug_struct("HierarchyChange")
             .field("r#type", &self.r#type())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -13891,6 +13911,7 @@
         f.debug_struct("HierarchyChangeBuf")
             .field("r#type", &self.r#type())
             .field("len", &self.len())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -15427,8 +15448,9 @@
     }
 
     pub fn data(&self) -> DeviceClassData {
+        let r#type = self.r#type();
         let params = DeviceClassDataParams {
-            r#type: self.r#type() as usize,
+            r#type: r#type as usize,
         };
         let offset = 6usize;
         let switch = (self.r#type() as usize);
@@ -15530,6 +15552,7 @@
             .field("r#type", &self.r#type())
             .field("len", &self.len())
             .field("sourceid", &self.sourceid())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -15540,6 +15563,7 @@
             .field("r#type", &self.r#type())
             .field("len", &self.len())
             .field("sourceid", &self.sourceid())
+            .field("data", &self.data())
             .finish()
     }
 }
@@ -22815,9 +22839,11 @@
     }
 
     pub fn items(&self) -> GetDevicePropertyReplyItems {
+        let format = self.format();
+        let num_items = self.num_items();
         let params = GetDevicePropertyReplyItemsParams {
-            format: self.format() as usize,
-            num_items: self.num_items() as usize,
+            format: format as usize,
+            num_items: num_items as usize,
         };
         let offset = 32usize;
         let switch = (self.format() as usize);
@@ -22852,6 +22878,7 @@
             .field("format", &self.format())
             .field("device_id", &self.device_id())
             .field("pad", &10)
+            .field("items", &self.items())
             .finish()
     }
 }
@@ -25424,9 +25451,11 @@
     }
 
     pub fn items(&self) -> XiGetPropertyReplyItems {
+        let format = self.format();
+        let num_items = self.num_items();
         let params = XiGetPropertyReplyItemsParams {
-            format: self.format() as usize,
-            num_items: self.num_items() as usize,
+            format: format as usize,
+            num_items: num_items as usize,
         };
         let offset = 32usize;
         let switch = (self.format() as usize);
@@ -25460,6 +25489,7 @@
             .field("num_items", &self.num_items())
             .field("format", &self.format())
             .field("pad", &11)
+            .field("items", &self.items())
             .finish()
     }
 }
diff -ur gen/previous/xkb.rs gen/current/xkb.rs
--- gen/previous/xkb.rs	2021-12-04 12:12:32.736916956 +0100
+++ gen/current/xkb.rs	2021-12-05 09:53:17.131778398 +0100
@@ -13565,6 +13565,34 @@
             std::mem::transmute::<u32, VMod>(val)
         }
     }
+
+    pub fn map(&self) -> Vec<GetMapReplyMap> {
+        let present = self.present().bits();
+        let n_key_actions = self.n_key_actions();
+        let n_key_syms = self.n_key_syms();
+        let n_types = self.n_types();
+        let total_actions = self.total_actions();
+        let total_key_behaviors = self.total_key_behaviors();
+        let total_key_explicit = self.total_key_explicit();
+        let total_mod_map_keys = self.total_mod_map_keys();
+        let total_v_mod_map_keys = self.total_v_mod_map_keys();
+        let virtual_mods = self.virtual_mods().bits();
+        let params = GetMapReplyMapParams {
+            present: present as usize,
+            n_key_actions: n_key_actions as usize,
+            n_key_syms: n_key_syms as usize,
+            n_types: n_types as usize,
+            total_actions: total_actions as usize,
+            total_key_behaviors: total_key_behaviors as usize,
+            total_key_explicit: total_key_explicit as usize,
+            total_mod_map_keys: total_mod_map_keys as usize,
+            total_v_mod_map_keys: total_v_mod_map_keys as usize,
+            virtual_mods: virtual_mods as usize,
+        };
+        let offset = 40usize;
+        let switch = (self.present().bits() as usize);
+        unsafe { GetMapReplyMap::from_wire_data(self.wire_ptr().add(offset), switch, params) }
+    }
 }
 
 impl base::Reply for GetMapReply {
@@ -13613,6 +13641,7 @@
             .field("total_v_mod_map_keys", &self.total_v_mod_map_keys())
             .field("pad", &1)
             .field("virtual_mods", &self.virtual_mods())
+            .field("map", &self.map())
             .finish()
     }
 }
@@ -15238,6 +15267,32 @@
             *ptr
         }
     }
+
+    pub fn value_list(&self) -> Vec<GetNamesReplyValueList> {
+        let which = self.which().bits();
+        let group_names = self.group_names().bits();
+        let indicators = self.indicators();
+        let n_key_aliases = self.n_key_aliases();
+        let n_keys = self.n_keys();
+        let n_radio_groups = self.n_radio_groups();
+        let n_types = self.n_types();
+        let virtual_mods = self.virtual_mods().bits();
+        let params = GetNamesReplyValueListParams {
+            which: which as usize,
+            group_names: group_names as usize,
+            indicators: indicators as usize,
+            n_key_aliases: n_key_aliases as usize,
+            n_keys: n_keys as usize,
+            n_radio_groups: n_radio_groups as usize,
+            n_types: n_types as usize,
+            virtual_mods: virtual_mods as usize,
+        };
+        let offset = 32usize;
+        let switch = (self.which().bits() as usize);
+        unsafe {
+            GetNamesReplyValueList::from_wire_data(self.wire_ptr().add(offset), switch, params)
+        }
+    }
 }
 
 impl base::Reply for GetNamesReply {
@@ -15272,6 +15327,7 @@
             .field("n_key_aliases", &self.n_key_aliases())
             .field("n_kt_levels", &self.n_kt_levels())
             .field("pad", &4)
+            .field("value_list", &self.value_list())
             .finish()
     }
 }
@@ -16410,6 +16466,18 @@
             std::mem::transmute::<u32, GbnDetail>(val)
         }
     }
+
+    pub fn replies(&self) -> Vec<GetKbdByNameReplyReplies> {
+        let reported = self.reported().bits();
+        let params = GetKbdByNameReplyRepliesParams {
+            reported: reported as usize,
+        };
+        let offset = 32usize;
+        let switch = (self.reported().bits() as usize);
+        unsafe {
+            GetKbdByNameReplyReplies::from_wire_data(self.wire_ptr().add(offset), switch, params)
+        }
+    }
 }
 
 impl base::Reply for GetKbdByNameReply {
@@ -16438,6 +16506,7 @@
             .field("found", &self.found())
             .field("reported", &self.reported())
             .field("pad", &16)
+            .field("replies", &self.replies())
             .finish()
     }
 }
```