### PR TITLE
match format in property debug impl

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -2282,6 +2282,39 @@ impl CodeGen {
             out,
             "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{"
         )?;
+        for f in fields {
+            match f {
+                Field::List {
+                    name,
+                    is_prop: true,
+                    ..
+                } => {
+                    writeln!(
+                        out,
+                        "{}let {}: Box<dyn std::fmt::Debug> = match self.format() {{",
+                        cg::ind(2),
+                        name
+                    )?;
+                    for format in [8, 16, 32] {
+                        writeln!(
+                            out,
+                            "{}{} => Box::new(self.{}::<u{}>()),",
+                            cg::ind(3),
+                            format,
+                            name,
+                            format
+                        )?;
+                    }
+                    writeln!(
+                        out,
+                        "{}format => unreachable!(\"impossible prop format: {{}}\", format),",
+                        cg::ind(3)
+                    )?;
+                    writeln!(out, "{}}};", cg::ind(2))?;
+                }
+                _ => {}
+            }
+        }
         writeln!(out, "        f.debug_struct(\"{}\")", rs_typ)?;
         for f in fields {
             match f {
@@ -2293,13 +2326,7 @@ impl CodeGen {
                     is_prop: true,
                     ..
                 } => {
-                    writeln!(
-                        out,
-                        "{}.field(\"{}\", &self.{}::<u8>())",
-                        cg::ind(3),
-                        name,
-                        name
-                    )?;
+                    writeln!(out, "{}.field(\"{}\", &*{})", cg::ind(3), name, name)?;
                 }
                 Field::List { name, wire_sz, .. } if wire_sz.params().is_empty() => {
                     writeln!(out, "{}.field(\"{}\", &self.{}())", cg::ind(3), name, name)?;


### PR DESCRIPTION
diff:
```diff
diff -ur gen/previous/randr.rs gen/current/randr.rs
--- gen/previous/randr.rs	2021-12-05 10:01:04.962013862 +0100
+++ gen/current/randr.rs	2021-12-05 10:23:15.074831143 +0100
@@ -4977,6 +4977,12 @@
 
 impl std::fmt::Debug for GetOutputPropertyReply {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data: Box<dyn std::fmt::Debug> = match self.format() {
+            8 => Box::new(self.data::<u8>()),
+            16 => Box::new(self.data::<u16>()),
+            32 => Box::new(self.data::<u32>()),
+            format => unreachable!("impossible prop format: {}", format),
+        };
         f.debug_struct("GetOutputPropertyReply")
             .field("response_type", &self.response_type())
             .field("format", &self.format())
@@ -4986,7 +4992,7 @@
             .field("bytes_after", &self.bytes_after())
             .field("num_items", &self.num_items())
             .field("pad", &12)
-            .field("data", &self.data::<u8>())
+            .field("data", &*data)
             .finish()
     }
 }
@@ -9364,6 +9370,12 @@
 
 impl std::fmt::Debug for GetProviderPropertyReply {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data: Box<dyn std::fmt::Debug> = match self.format() {
+            8 => Box::new(self.data::<u8>()),
+            16 => Box::new(self.data::<u16>()),
+            32 => Box::new(self.data::<u32>()),
+            format => unreachable!("impossible prop format: {}", format),
+        };
         f.debug_struct("GetProviderPropertyReply")
             .field("response_type", &self.response_type())
             .field("format", &self.format())
@@ -9373,7 +9385,7 @@
             .field("bytes_after", &self.bytes_after())
             .field("num_items", &self.num_items())
             .field("pad", &12)
-            .field("data", &self.data::<u8>())
+            .field("data", &*data)
             .finish()
     }
 }
diff -ur gen/previous/xproto.rs gen/current/xproto.rs
--- gen/previous/xproto.rs	2021-12-05 10:01:07.582009363 +0100
+++ gen/current/xproto.rs	2021-12-05 10:23:17.674854705 +0100
@@ -13141,6 +13141,12 @@
 
 impl std::fmt::Debug for GetPropertyReply {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value: Box<dyn std::fmt::Debug> = match self.format() {
+            8 => Box::new(self.value::<u8>()),
+            16 => Box::new(self.value::<u16>()),
+            32 => Box::new(self.value::<u32>()),
+            format => unreachable!("impossible prop format: {}", format),
+        };
         f.debug_struct("GetPropertyReply")
             .field("response_type", &self.response_type())
             .field("format", &self.format())
@@ -13150,7 +13156,7 @@
             .field("bytes_after", &self.bytes_after())
             .field("value_len", &self.value_len())
             .field("pad", &12)
-            .field("value", &self.value::<u8>())
+            .field("value", &*value)
             .finish()
     }
 }
```