### PR TITLE
events and errors impl Send and Sync

### DIFF
--- a/build/cg/error.rs
+++ b/build/cg/error.rs
@@ -197,6 +197,10 @@ impl CodeGen {
             writeln!(out, "        unsafe {{ libc::free(self.raw as *mut _); }}")?;
             writeln!(out, "    }}")?;
             writeln!(out, "}}")?;
+
+            writeln!(out)?;
+            writeln!(out, "unsafe impl Send for {} {{}}", error.rs_typ)?;
+            writeln!(out, "unsafe impl Sync for {} {{}}", error.rs_typ)?;
         }
 
         writeln!(out)?;

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -335,6 +335,10 @@ impl CodeGen {
             writeln!(out, "        unsafe {{ libc::free(self.raw as *mut _); }}")?;
             writeln!(out, "    }}")?;
             writeln!(out, "}}")?;
+
+            writeln!(out)?;
+            writeln!(out, "unsafe impl Send for {} {{}}", event.rs_typ)?;
+            writeln!(out, "unsafe impl Sync for {} {{}}", event.rs_typ)?;
         }
 
         writeln!(out)?;


### PR DESCRIPTION
Rationale: they own their data and do not mutate any state.
`Send` and `Sync` is therefore safe to implement.

fixes #128 