### PR TITLE
Fix enums with single field

### DIFF
--- a/TODO_v1.md
+++ b/TODO_v1.md
@@ -21,17 +21,21 @@
  - [x] Finalize switches naming (e.g. x::CreateWindowValueList -> x::Cw)
  - [x] Report request name in protocol errors
  - [x] Support of xinput::SendExtensionEvent
- - [x] Create example with XInput (pen tablet?)
-    - [ ] Update with valuator classes
- - [ ] Create example with Vulkan
- - [ ] Create example with wgpu
+ - [ ] Examples
+    - [x] Port old examples
+    - [x] Create example with XInput (pen tablet?)
+        - [ ] Update with valuator classes
+    - [ ] Create example with Vulkan
+    - [ ] Create example with wgpu
+    - [ ] Create example using an Fd API
  - Missing API tweaks:
     - [x] Cw::EventMask should take an EventMask
-    - [ ] fix xkb::GetMapReplyMap::VirtualMods takes ModMask
+    - [x] fix xkb::GetMapReplyMap::VirtualMods takes ModMask
     - [ ] use altenum in xinput for Device (All, Master or Id (or slave?))
     - [x] xinput::ListInputDevice has incomplete InputInfo
     - [x] remove fieldrefs in switches
     - [x] Debug props should match format
+    - [ ] Fix Fd API
  - [x] Porting toy-xcb
  - [x] Porting xkbcommon-rs
  - [ ] Porting x11-clipboard


### PR DESCRIPTION
code generation diff: 
```diff
diff -ur gen/previous/xinput.rs gen/current/xinput.rs
--- gen/previous/xinput.rs	2021-12-19 22:13:53.320098351 +0100
+++ gen/current/xinput.rs	2021-12-19 22:30:31.316809011 +0100
@@ -11183,9 +11183,7 @@
         status: u8,
         iscore: u8,
     },
-    Enable {
-        enable: u8,
-    },
+    Enable(u8),
     AbsArea {
         offset_x: u32,
         offset_y: u32,
@@ -11278,7 +11276,7 @@
             let enable = *(wire_data.add(offset) as *const u8);
             offset += std::mem::size_of::<u8>();
             offset += 3; // pad
-            return DeviceStateData::Enable { enable };
+            return DeviceStateData::Enable(enable);
         }
         if expr == (DeviceControl::AbsArea as usize) {
             let mut offset = 0usize;
@@ -11430,7 +11428,7 @@
                 sz += 1;
                 sz += 2;
             }
-            DeviceStateData::Enable { .. } => {
+            DeviceStateData::Enable(..) => {
                 sz += 1;
                 sz += 3;
             }
@@ -11491,7 +11489,7 @@
                 offset += iscore.serialize(&mut wire_buf[offset..]);
                 offset += 2;
             }
-            DeviceStateData::Enable { enable, .. } => {
+            DeviceStateData::Enable(enable, ..) => {
                 offset += enable.serialize(&mut wire_buf[offset..]);
                 offset += 3;
             }
@@ -12458,12 +12456,8 @@
         rotation: u32,
         button_threshold: u32,
     },
-    Core {
-        status: u8,
-    },
-    Enable {
-        enable: u8,
-    },
+    Core(u8),
+    Enable(u8),
     AbsArea {
         offset_x: u32,
         offset_y: u32,
@@ -12535,14 +12529,14 @@
             let status = *(wire_data.add(offset) as *const u8);
             offset += std::mem::size_of::<u8>();
             offset += 3; // pad
-            return DeviceCtlData::Core { status };
+            return DeviceCtlData::Core(status);
         }
         if expr == (DeviceControl::Enable as usize) {
             let mut offset = 0usize;
             let enable = *(wire_data.add(offset) as *const u8);
             offset += std::mem::size_of::<u8>();
             offset += 3; // pad
-            return DeviceCtlData::Enable { enable };
+            return DeviceCtlData::Enable(enable);
         }
         if expr == (DeviceControl::AbsArea as usize) {
             let mut offset = 0usize;
@@ -12678,11 +12672,11 @@
                 sz += 4;
                 sz += 4;
             }
-            DeviceCtlData::Core { .. } => {
+            DeviceCtlData::Core(..) => {
                 sz += 1;
                 sz += 3;
             }
-            DeviceCtlData::Enable { .. } => {
+            DeviceCtlData::Enable(..) => {
                 sz += 1;
                 sz += 3;
             }
@@ -12733,11 +12727,11 @@
                 offset += rotation.serialize(&mut wire_buf[offset..]);
                 offset += button_threshold.serialize(&mut wire_buf[offset..]);
             }
-            DeviceCtlData::Core { status, .. } => {
+            DeviceCtlData::Core(status, ..) => {
                 offset += status.serialize(&mut wire_buf[offset..]);
                 offset += 3;
             }
-            DeviceCtlData::Enable { enable, .. } => {
+            DeviceCtlData::Enable(enable, ..) => {
                 offset += enable.serialize(&mut wire_buf[offset..]);
                 offset += 3;
             }
@@ -13632,9 +13626,7 @@
         deviceid: DeviceId,
         master: DeviceId,
     },
-    DetachSlave {
-        deviceid: DeviceId,
-    },
+    DetachSlave(DeviceId),
 }
 
 impl HierarchyChangeData {
@@ -13697,7 +13689,7 @@
             let deviceid = *(wire_data.add(offset) as *const DeviceId);
             offset += std::mem::size_of::<DeviceId>();
             offset += 2; // pad
-            return HierarchyChangeData::DetachSlave { deviceid };
+            return HierarchyChangeData::DetachSlave(deviceid);
         }
         unreachable!("Could not match any expression for HierarchyChangeData");
     }
@@ -13789,7 +13781,7 @@
                 sz += 2;
                 sz += 2;
             }
-            HierarchyChangeData::DetachSlave { .. } => {
+            HierarchyChangeData::DetachSlave(..) => {
                 sz += 2;
                 sz += 2;
             }
@@ -13835,7 +13827,7 @@
                 offset += deviceid.serialize(&mut wire_buf[offset..]);
                 offset += master.serialize(&mut wire_buf[offset..]);
             }
-            HierarchyChangeData::DetachSlave { deviceid, .. } => {
+            HierarchyChangeData::DetachSlave(deviceid, ..) => {
                 offset += deviceid.serialize(&mut wire_buf[offset..]);
                 offset += 2;
             }
@@ -16441,8 +16433,8 @@
 
 #[derive(Clone, Debug)]
 pub enum ChangeDevicePropertyItems {
-    N8Bits { data8: Vec<u8> },
-    N16Bits { data16: Vec<u16> },
+    N8Bits(Vec<u8>),
+    N16Bits(Vec<u16>),
     N32Bits(Vec<u32>),
 }
 
@@ -16464,7 +16456,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return ChangeDevicePropertyItems::N8Bits { data8 };
+            return ChangeDevicePropertyItems::N8Bits(data8);
         }
         if expr == (PropertyFormat::N16Bits as usize) {
             let mut offset = 0usize;
@@ -16476,7 +16468,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return ChangeDevicePropertyItems::N16Bits { data16 };
+            return ChangeDevicePropertyItems::N16Bits(data16);
         }
         if expr == (PropertyFormat::N32Bits as usize) {
             let mut offset = 0usize;
@@ -16535,13 +16527,13 @@
     fn wire_len(&self) -> usize {
         let mut sz = 0usize;
         match self {
-            ChangeDevicePropertyItems::N8Bits { data8, .. } => {
+            ChangeDevicePropertyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     sz += el.wire_len();
                 }
                 sz += base::align_pad(sz, 4);
             }
-            ChangeDevicePropertyItems::N16Bits { data16, .. } => {
+            ChangeDevicePropertyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     sz += el.wire_len();
                 }
@@ -16559,13 +16551,13 @@
     fn serialize(&self, wire_buf: &mut [u8]) -> usize {
         let mut offset = 0usize;
         match self {
-            ChangeDevicePropertyItems::N8Bits { data8, .. } => {
+            ChangeDevicePropertyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
                 offset += base::align_pad(offset, 4);
             }
-            ChangeDevicePropertyItems::N16Bits { data16, .. } => {
+            ChangeDevicePropertyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
@@ -16589,8 +16581,8 @@
 
 #[derive(Clone, Debug)]
 pub enum GetDevicePropertyReplyItems {
-    N8Bits { data8: Vec<u8> },
-    N16Bits { data16: Vec<u16> },
+    N8Bits(Vec<u8>),
+    N16Bits(Vec<u16>),
     N32Bits(Vec<u32>),
 }
 
@@ -16612,7 +16604,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return GetDevicePropertyReplyItems::N8Bits { data8 };
+            return GetDevicePropertyReplyItems::N8Bits(data8);
         }
         if expr == (PropertyFormat::N16Bits as usize) {
             let mut offset = 0usize;
@@ -16624,7 +16616,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return GetDevicePropertyReplyItems::N16Bits { data16 };
+            return GetDevicePropertyReplyItems::N16Bits(data16);
         }
         if expr == (PropertyFormat::N32Bits as usize) {
             let mut offset = 0usize;
@@ -16683,13 +16675,13 @@
     fn wire_len(&self) -> usize {
         let mut sz = 0usize;
         match self {
-            GetDevicePropertyReplyItems::N8Bits { data8, .. } => {
+            GetDevicePropertyReplyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     sz += el.wire_len();
                 }
                 sz += base::align_pad(sz, 4);
             }
-            GetDevicePropertyReplyItems::N16Bits { data16, .. } => {
+            GetDevicePropertyReplyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     sz += el.wire_len();
                 }
@@ -16707,13 +16699,13 @@
     fn serialize(&self, wire_buf: &mut [u8]) -> usize {
         let mut offset = 0usize;
         match self {
-            GetDevicePropertyReplyItems::N8Bits { data8, .. } => {
+            GetDevicePropertyReplyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
                 offset += base::align_pad(offset, 4);
             }
-            GetDevicePropertyReplyItems::N16Bits { data16, .. } => {
+            GetDevicePropertyReplyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
@@ -16737,8 +16729,8 @@
 
 #[derive(Clone, Debug)]
 pub enum XiChangePropertyItems {
-    N8Bits { data8: Vec<u8> },
-    N16Bits { data16: Vec<u16> },
+    N8Bits(Vec<u8>),
+    N16Bits(Vec<u16>),
     N32Bits(Vec<u32>),
 }
 
@@ -16760,7 +16752,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return XiChangePropertyItems::N8Bits { data8 };
+            return XiChangePropertyItems::N8Bits(data8);
         }
         if expr == (PropertyFormat::N16Bits as usize) {
             let mut offset = 0usize;
@@ -16772,7 +16764,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return XiChangePropertyItems::N16Bits { data16 };
+            return XiChangePropertyItems::N16Bits(data16);
         }
         if expr == (PropertyFormat::N32Bits as usize) {
             let mut offset = 0usize;
@@ -16833,13 +16825,13 @@
     fn wire_len(&self) -> usize {
         let mut sz = 0usize;
         match self {
-            XiChangePropertyItems::N8Bits { data8, .. } => {
+            XiChangePropertyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     sz += el.wire_len();
                 }
                 sz += base::align_pad(sz, 4);
             }
-            XiChangePropertyItems::N16Bits { data16, .. } => {
+            XiChangePropertyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     sz += el.wire_len();
                 }
@@ -16857,13 +16849,13 @@
     fn serialize(&self, wire_buf: &mut [u8]) -> usize {
         let mut offset = 0usize;
         match self {
-            XiChangePropertyItems::N8Bits { data8, .. } => {
+            XiChangePropertyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
                 offset += base::align_pad(offset, 4);
             }
-            XiChangePropertyItems::N16Bits { data16, .. } => {
+            XiChangePropertyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
@@ -16887,8 +16879,8 @@
 
 #[derive(Clone, Debug)]
 pub enum XiGetPropertyReplyItems {
-    N8Bits { data8: Vec<u8> },
-    N16Bits { data16: Vec<u16> },
+    N8Bits(Vec<u8>),
+    N16Bits(Vec<u16>),
     N32Bits(Vec<u32>),
 }
 
@@ -16910,7 +16902,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return XiGetPropertyReplyItems::N8Bits { data8 };
+            return XiGetPropertyReplyItems::N8Bits(data8);
         }
         if expr == (PropertyFormat::N16Bits as usize) {
             let mut offset = 0usize;
@@ -16922,7 +16914,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            return XiGetPropertyReplyItems::N16Bits { data16 };
+            return XiGetPropertyReplyItems::N16Bits(data16);
         }
         if expr == (PropertyFormat::N32Bits as usize) {
             let mut offset = 0usize;
@@ -16981,13 +16973,13 @@
     fn wire_len(&self) -> usize {
         let mut sz = 0usize;
         match self {
-            XiGetPropertyReplyItems::N8Bits { data8, .. } => {
+            XiGetPropertyReplyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     sz += el.wire_len();
                 }
                 sz += base::align_pad(sz, 4);
             }
-            XiGetPropertyReplyItems::N16Bits { data16, .. } => {
+            XiGetPropertyReplyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     sz += el.wire_len();
                 }
@@ -17005,13 +16997,13 @@
     fn serialize(&self, wire_buf: &mut [u8]) -> usize {
         let mut offset = 0usize;
         match self {
-            XiGetPropertyReplyItems::N8Bits { data8, .. } => {
+            XiGetPropertyReplyItems::N8Bits(data8, ..) => {
                 for el in data8 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
                 offset += base::align_pad(offset, 4);
             }
-            XiGetPropertyReplyItems::N16Bits { data16, .. } => {
+            XiGetPropertyReplyItems::N16Bits(data16, ..) => {
                 for el in data16 {
                     offset += el.serialize(&mut wire_buf[offset..]);
                 }
diff -ur gen/previous/xkb.rs gen/current/xkb.rs
--- gen/previous/xkb.rs	2021-12-19 22:13:53.603447422 +0100
+++ gen/current/xkb.rs	2021-12-19 22:30:31.656815082 +0100
@@ -8158,15 +8158,9 @@
         acts_rtrn_acts: Vec<Action>,
     },
     KeyBehaviors(Vec<SetBehavior>),
-    VirtualMods {
-        vmods_rtrn: Vec<xproto::ModMask>,
-    },
-    ExplicitComponents {
-        explicit_rtrn: Vec<SetExplicit>,
-    },
-    ModifierMap {
-        modmap_rtrn: Vec<KeyModMap>,
-    },
+    VirtualMods(Vec<xproto::ModMask>),
+    ExplicitComponents(Vec<SetExplicit>),
+    ModifierMap(Vec<KeyModMap>),
     VirtualModMap(Vec<KeyVModMap>),
 }
 
@@ -8264,7 +8258,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(GetMapReplyMap::VirtualMods { vmods_rtrn });
+            result.push(GetMapReplyMap::VirtualMods(vmods_rtrn));
         }
         if expr & (MapPart::EXPLICIT_COMPONENTS.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -8276,7 +8270,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(GetMapReplyMap::ExplicitComponents { explicit_rtrn });
+            result.push(GetMapReplyMap::ExplicitComponents(explicit_rtrn));
         }
         if expr & (MapPart::MODIFIER_MAP.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -8288,7 +8282,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(GetMapReplyMap::ModifierMap { modmap_rtrn });
+            result.push(GetMapReplyMap::ModifierMap(modmap_rtrn));
         }
         if expr & (MapPart::VIRTUAL_MOD_MAP.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -8462,17 +8456,17 @@
                         sz += el.wire_len();
                     }
                 }
-                GetMapReplyMap::VirtualMods { vmods_rtrn, .. } => {
+                GetMapReplyMap::VirtualMods(vmods_rtrn, ..) => {
                     sz += vmods_rtrn.len() * std::mem::size_of::<u8>();
                     sz += base::align_pad(sz, 4);
                 }
-                GetMapReplyMap::ExplicitComponents { explicit_rtrn, .. } => {
+                GetMapReplyMap::ExplicitComponents(explicit_rtrn, ..) => {
                     for el in explicit_rtrn {
                         sz += el.wire_len();
                     }
                     sz += base::align_pad(sz, 4);
                 }
-                GetMapReplyMap::ModifierMap { modmap_rtrn, .. } => {
+                GetMapReplyMap::ModifierMap(modmap_rtrn, ..) => {
                     for el in modmap_rtrn {
                         sz += el.wire_len();
                     }
@@ -8520,19 +8514,19 @@
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
                 }
-                GetMapReplyMap::VirtualMods { vmods_rtrn, .. } => {
+                GetMapReplyMap::VirtualMods(vmods_rtrn, ..) => {
                     for el in vmods_rtrn {
                         offset += (el.bits() as u8).serialize(&mut wire_buf[offset..]);
                     }
                     offset += base::align_pad(offset, 4);
                 }
-                GetMapReplyMap::ExplicitComponents { explicit_rtrn, .. } => {
+                GetMapReplyMap::ExplicitComponents(explicit_rtrn, ..) => {
                     for el in explicit_rtrn {
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
                     offset += base::align_pad(offset, 4);
                 }
-                GetMapReplyMap::ModifierMap { modmap_rtrn, .. } => {
+                GetMapReplyMap::ModifierMap(modmap_rtrn, ..) => {
                     for el in modmap_rtrn {
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
@@ -8572,9 +8566,7 @@
         actions: Vec<Action>,
     },
     KeyBehaviors(Vec<SetBehavior>),
-    VirtualMods {
-        vmods: Vec<u8>,
-    },
+    VirtualMods(Vec<u8>),
     ExplicitComponents(Vec<SetExplicit>),
     ModifierMap(Vec<KeyModMap>),
     VirtualModMap(Vec<KeyVModMap>),
@@ -8674,7 +8666,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(SetMapValues::VirtualMods { vmods });
+            result.push(SetMapValues::VirtualMods(vmods));
         }
         if expr & (MapPart::EXPLICIT_COMPONENTS.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -8866,7 +8858,7 @@
                         sz += el.wire_len();
                     }
                 }
-                SetMapValues::VirtualMods { vmods, .. } => {
+                SetMapValues::VirtualMods(vmods, ..) => {
                     for el in vmods {
                         sz += el.wire_len();
                     }
@@ -8924,7 +8916,7 @@
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
                 }
-                SetMapValues::VirtualMods { vmods, .. } => {
+                SetMapValues::VirtualMods(vmods, ..) => {
                     for el in vmods {
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
@@ -9988,15 +9980,9 @@
         acts_rtrn_acts: Vec<Action>,
     },
     KeyBehaviors(Vec<SetBehavior>),
-    VirtualMods {
-        vmods_rtrn: Vec<xproto::ModMask>,
-    },
-    ExplicitComponents {
-        explicit_rtrn: Vec<SetExplicit>,
-    },
-    ModifierMap {
-        modmap_rtrn: Vec<KeyModMap>,
-    },
+    VirtualMods(Vec<xproto::ModMask>),
+    ExplicitComponents(Vec<SetExplicit>),
+    ModifierMap(Vec<KeyModMap>),
     VirtualModMap(Vec<KeyVModMap>),
 }
 
@@ -10094,7 +10080,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(GetKbdByNameReplyRepliesMap::VirtualMods { vmods_rtrn });
+            result.push(GetKbdByNameReplyRepliesMap::VirtualMods(vmods_rtrn));
         }
         if expr & (MapPart::EXPLICIT_COMPONENTS.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -10106,7 +10092,9 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(GetKbdByNameReplyRepliesMap::ExplicitComponents { explicit_rtrn });
+            result.push(GetKbdByNameReplyRepliesMap::ExplicitComponents(
+                explicit_rtrn,
+            ));
         }
         if expr & (MapPart::MODIFIER_MAP.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -10118,7 +10106,7 @@
                 data.to_vec()
             };
             offset += base::align_pad(offset, 4);
-            result.push(GetKbdByNameReplyRepliesMap::ModifierMap { modmap_rtrn });
+            result.push(GetKbdByNameReplyRepliesMap::ModifierMap(modmap_rtrn));
         }
         if expr & (MapPart::VIRTUAL_MOD_MAP.bits() as usize) != 0 {
             let mut offset = 0usize;
@@ -10292,17 +10280,17 @@
                         sz += el.wire_len();
                     }
                 }
-                GetKbdByNameReplyRepliesMap::VirtualMods { vmods_rtrn, .. } => {
+                GetKbdByNameReplyRepliesMap::VirtualMods(vmods_rtrn, ..) => {
                     sz += vmods_rtrn.len() * std::mem::size_of::<u8>();
                     sz += base::align_pad(sz, 4);
                 }
-                GetKbdByNameReplyRepliesMap::ExplicitComponents { explicit_rtrn, .. } => {
+                GetKbdByNameReplyRepliesMap::ExplicitComponents(explicit_rtrn, ..) => {
                     for el in explicit_rtrn {
                         sz += el.wire_len();
                     }
                     sz += base::align_pad(sz, 4);
                 }
-                GetKbdByNameReplyRepliesMap::ModifierMap { modmap_rtrn, .. } => {
+                GetKbdByNameReplyRepliesMap::ModifierMap(modmap_rtrn, ..) => {
                     for el in modmap_rtrn {
                         sz += el.wire_len();
                     }
@@ -10350,19 +10338,19 @@
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
                 }
-                GetKbdByNameReplyRepliesMap::VirtualMods { vmods_rtrn, .. } => {
+                GetKbdByNameReplyRepliesMap::VirtualMods(vmods_rtrn, ..) => {
                     for el in vmods_rtrn {
                         offset += (el.bits() as u8).serialize(&mut wire_buf[offset..]);
                     }
                     offset += base::align_pad(offset, 4);
                 }
-                GetKbdByNameReplyRepliesMap::ExplicitComponents { explicit_rtrn, .. } => {
+                GetKbdByNameReplyRepliesMap::ExplicitComponents(explicit_rtrn, ..) => {
                     for el in explicit_rtrn {
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
                     offset += base::align_pad(offset, 4);
                 }
-                GetKbdByNameReplyRepliesMap::ModifierMap { modmap_rtrn, .. } => {
+                GetKbdByNameReplyRepliesMap::ModifierMap(modmap_rtrn, ..) => {
                     for el in modmap_rtrn {
                         offset += el.serialize(&mut wire_buf[offset..]);
                     }
```