### PR TITLE
fix requests and replies with fd

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1,6 +1,6 @@
-use crate::cg::request::fieldref_get_value;
+use crate::cg;
+use crate::cg::request::{field_is_fd, fieldref_get_value, request_fieldref_emitted};
 use crate::cg::util;
-use crate::cg::{self, request::request_fieldref_emitted};
 use crate::ir;
 
 use super::UnionTypeField;
@@ -1447,13 +1447,17 @@ impl CodeGen {
         fields: &[Field],
     ) -> io::Result<()> {
         for f in fields {
-            writeln!(out)?;
+            if field_is_fd(f) {
+                // fd fields are handled directly in request.rs
+                continue;
+            }
             if self.handle_client_message_data(out, struct_rs_typ, f)? {
                 continue;
             }
             if self.handle_randr_notify_data(out, struct_rs_typ, f)? {
                 continue;
             }
+            writeln!(out)?;
             match f {
                 Field::Field {
                     name,


### PR DESCRIPTION
diff of code generation:
```diff
diff -ur gen/previous/dri3.rs gen/current/dri3.rs
--- gen/previous/dri3.rs	2021-12-20 11:43:47.581608182 +0100
+++ gen/current/dri3.rs	2021-12-20 12:12:31.988222480 +0100
@@ -315,9 +315,11 @@
 
     pub fn device_fd(&self) -> RawFd {
         unsafe {
-            let offset = 8usize;
-            let ptr = self.wire_ptr().add(offset) as *const RawFd;
-            *ptr
+            assert!(
+                self.nfd() == 1,
+                "Expected a single Fd for OpenReply::device_fd"
+            );
+            *(self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd)
         }
     }
 }
@@ -437,9 +439,9 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
-                base::RequestFlags::CHECKED
+                base::RequestFlags::CHECKED | base::RequestFlags::REPLY_FDS
             } else {
-                base::RequestFlags::NONE
+                base::RequestFlags::NONE | base::RequestFlags::REPLY_FDS
             };
 
             xcb_send_request64(
@@ -495,8 +497,9 @@
                 iov_base: std::ptr::null_mut(),
                 iov_len: 0,
             }; 4];
+            let fds: [RawFd; 1] = [self.pixmap_fd];
 
-            let buf0: &mut [u8] = &mut [0; 28];
+            let buf0: &mut [u8] = &mut [0; 24];
             self.pixmap.serialize(&mut buf0[4..]);
             self.drawable.serialize(&mut buf0[8..]);
             self.size.serialize(&mut buf0[12..]);
@@ -505,9 +508,8 @@
             self.stride.serialize(&mut buf0[20..]);
             self.depth.serialize(&mut buf0[22..]);
             self.bpp.serialize(&mut buf0[23..]);
-            self.pixmap_fd.serialize(&mut buf0[24..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
-            sections[2].iov_len = 28;
+            sections[2].iov_len = 24;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
@@ -516,11 +518,13 @@
                 base::RequestFlags::NONE
             };
 
-            xcb_send_request64(
+            xcb_send_request_with_fds64(
                 c.get_raw_conn(),
                 flags.bits() as _,
                 sections.as_mut_ptr().add(2),
                 &mut protocol_request as *mut _,
+                fds.len() as _,
+                fds.as_ptr() as *mut _,
             )
         }
     }
@@ -628,9 +632,11 @@
 
     pub fn pixmap_fd(&self) -> RawFd {
         unsafe {
-            let offset = 20usize;
-            let ptr = self.wire_ptr().add(offset) as *const RawFd;
-            *ptr
+            assert!(
+                self.nfd() == 1,
+                "Expected a single Fd for BufferFromPixmapReply::pixmap_fd"
+            );
+            *(self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd)
         }
     }
 }
@@ -754,9 +760,9 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
-                base::RequestFlags::CHECKED
+                base::RequestFlags::CHECKED | base::RequestFlags::REPLY_FDS
             } else {
-                base::RequestFlags::NONE
+                base::RequestFlags::NONE | base::RequestFlags::REPLY_FDS
             };
 
             xcb_send_request64(
@@ -807,14 +813,14 @@
                 iov_base: std::ptr::null_mut(),
                 iov_len: 0,
             }; 4];
+            let fds: [RawFd; 1] = [self.fence_fd];
 
-            let buf0: &mut [u8] = &mut [0; 20];
+            let buf0: &mut [u8] = &mut [0; 16];
             self.drawable.serialize(&mut buf0[4..]);
             self.fence.serialize(&mut buf0[8..]);
             (if self.initially_triggered { 1u8 } else { 0u8 }).serialize(&mut buf0[12..]);
-            self.fence_fd.serialize(&mut buf0[16..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
-            sections[2].iov_len = 20;
+            sections[2].iov_len = 16;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
@@ -823,11 +829,13 @@
                 base::RequestFlags::NONE
             };
 
-            xcb_send_request64(
+            xcb_send_request_with_fds64(
                 c.get_raw_conn(),
                 flags.bits() as _,
                 sections.as_mut_ptr().add(2),
                 &mut protocol_request as *mut _,
+                fds.len() as _,
+                fds.as_ptr() as *mut _,
             )
         }
     }
@@ -887,9 +895,11 @@
 
     pub fn fence_fd(&self) -> RawFd {
         unsafe {
-            let offset = 8usize;
-            let ptr = self.wire_ptr().add(offset) as *const RawFd;
-            *ptr
+            assert!(
+                self.nfd() == 1,
+                "Expected a single Fd for FdFromFenceReply::fence_fd"
+            );
+            *(self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd)
         }
     }
 }
@@ -1009,9 +1019,9 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
-                base::RequestFlags::CHECKED
+                base::RequestFlags::CHECKED | base::RequestFlags::REPLY_FDS
             } else {
-                base::RequestFlags::NONE
+                base::RequestFlags::NONE | base::RequestFlags::REPLY_FDS
             };
 
             xcb_send_request64(
@@ -1317,6 +1327,7 @@
                 iov_base: std::ptr::null_mut(),
                 iov_len: 0,
             }; 6];
+            let fds: &[RawFd] = self.buffers;
 
             let buf0: &mut [u8] = &mut [0; 64];
             self.pixmap.serialize(&mut buf0[4..]);
@@ -1349,11 +1360,13 @@
                 base::RequestFlags::NONE
             };
 
-            xcb_send_request64(
+            xcb_send_request_with_fds64(
                 c.get_raw_conn(),
                 flags.bits() as _,
                 sections.as_mut_ptr().add(2),
                 &mut protocol_request as *mut _,
+                fds.len() as _,
+                fds.as_ptr() as *mut _,
             )
         }
     }
@@ -1505,10 +1518,8 @@
 
     pub fn buffers(&self) -> &[RawFd] {
         unsafe {
-            let offset =
-                ((32usize + ((self.nfd() as usize) * 4usize)) + ((self.nfd() as usize) * 4usize));
-            let len = (self.nfd() as usize);
-            let ptr = self.wire_ptr().add(offset) as *const RawFd;
+            let len = self.nfd() as usize;
+            let ptr = self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd;
             std::slice::from_raw_parts(ptr, len)
         }
     }
@@ -1635,9 +1646,9 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
-                base::RequestFlags::CHECKED
+                base::RequestFlags::CHECKED | base::RequestFlags::REPLY_FDS
             } else {
-                base::RequestFlags::NONE
+                base::RequestFlags::NONE | base::RequestFlags::REPLY_FDS
             };
 
             xcb_send_request64(
diff -ur gen/previous/randr.rs gen/current/randr.rs
--- gen/previous/randr.rs	2021-12-20 11:43:48.254943579 +0100
+++ gen/current/randr.rs	2021-12-20 12:12:32.614895025 +0100
@@ -10096,9 +10096,11 @@
 
     pub fn master_fd(&self) -> RawFd {
         unsafe {
-            let offset = 8usize;
-            let ptr = self.wire_ptr().add(offset) as *const RawFd;
-            *ptr
+            assert!(
+                self.nfd() == 1,
+                "Expected a single Fd for CreateLeaseReply::master_fd"
+            );
+            *(self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd)
         }
     }
 }
@@ -10230,9 +10232,9 @@
             sections[7].iov_len = base::align_pad(sections[6].iov_len, 4);
 
             let flags = if checked {
-                base::RequestFlags::CHECKED
+                base::RequestFlags::CHECKED | base::RequestFlags::REPLY_FDS
             } else {
-                base::RequestFlags::NONE
+                base::RequestFlags::NONE | base::RequestFlags::REPLY_FDS
             };
 
             xcb_send_request64(
diff -ur gen/previous/shm.rs gen/current/shm.rs
--- gen/previous/shm.rs	2021-12-20 11:43:48.948279038 +0100
+++ gen/current/shm.rs	2021-12-20 12:12:33.328235047 +0100
@@ -1034,13 +1034,13 @@
                 iov_base: std::ptr::null_mut(),
                 iov_len: 0,
             }; 4];
+            let fds: [RawFd; 1] = [self.shm_fd];
 
-            let buf0: &mut [u8] = &mut [0; 16];
+            let buf0: &mut [u8] = &mut [0; 12];
             self.shmseg.serialize(&mut buf0[4..]);
-            self.shm_fd.serialize(&mut buf0[8..]);
-            (if self.read_only { 1u8 } else { 0u8 }).serialize(&mut buf0[12..]);
+            (if self.read_only { 1u8 } else { 0u8 }).serialize(&mut buf0[8..]);
             sections[2].iov_base = buf0.as_mut_ptr() as *mut _;
-            sections[2].iov_len = 16;
+            sections[2].iov_len = 12;
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
@@ -1049,11 +1049,13 @@
                 base::RequestFlags::NONE
             };
 
-            xcb_send_request64(
+            xcb_send_request_with_fds64(
                 c.get_raw_conn(),
                 flags.bits() as _,
                 sections.as_mut_ptr().add(2),
                 &mut protocol_request as *mut _,
+                fds.len() as _,
+                fds.as_ptr() as *mut _,
             )
         }
     }
@@ -1113,9 +1115,11 @@
 
     pub fn shm_fd(&self) -> RawFd {
         unsafe {
-            let offset = 8usize;
-            let ptr = self.wire_ptr().add(offset) as *const RawFd;
-            *ptr
+            assert!(
+                self.nfd() == 1,
+                "Expected a single Fd for CreateSegmentReply::shm_fd"
+            );
+            *(self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd)
         }
     }
 }
@@ -1237,9 +1241,9 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             let flags = if checked {
-                base::RequestFlags::CHECKED
+                base::RequestFlags::CHECKED | base::RequestFlags::REPLY_FDS
             } else {
-                base::RequestFlags::NONE
+                base::RequestFlags::NONE | base::RequestFlags::REPLY_FDS
             };
 
             xcb_send_request64(
```