### PR TITLE
Fix wire len calculation

### DIFF
--- a/TODO_v1.md
+++ b/TODO_v1.md
@@ -28,7 +28,7 @@
     - [ ] Create example with Vulkan
     - [ ] Create example with wgpu
     - [ ] Create example using an Fd API
- - Missing API tweaks:
+ - Missing API tweaks / fixes:
     - [x] Cw::EventMask should take an EventMask
     - [x] fix xkb::GetMapReplyMap::VirtualMods takes ModMask
     - [ ] use altenum in xinput for Device (All, Master or Id (or slave?))
@@ -37,6 +37,7 @@
     - [x] Debug props should match format
     - [x] Fix Fd API
     - [ ] Reply impl Send and Sync
+    - [x] Fix the wire_len calculation (32 + 4 * length)
  - [x] Porting toy-xcb
  - [x] Porting xkbcommon-rs
  - [ ] Porting x11-clipboard

--- a/build/cg/error.rs
+++ b/build/cg/error.rs
@@ -186,6 +186,8 @@ impl CodeGen {
                 out,
                 "    fn wire_ptr(&self) -> *const u8 {{ self.raw as *const u8 }}"
             )?;
+            writeln!(out)?;
+            writeln!(out, "    fn wire_len(&self) -> usize {{ 32 }}")?;
             self.emit_struct_accessors(out, &error.rs_typ, &error.fields)?;
             writeln!(out, "}}")?;
 

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -291,18 +291,12 @@ impl CodeGen {
             writeln!(out, "        self.raw")?;
             writeln!(out, "    }}")?;
 
-            let len_expr = if event.is_xge {
-                "self.length() as usize"
-            } else {
-                "32"
-            };
             writeln!(out)?;
             writeln!(out, "    fn as_slice(&self) -> &[u8] {{")?;
             writeln!(out, "        unsafe {{")?;
             writeln!(
                 out,
-                "            std::slice::from_raw_parts(self.raw as *const u8, {})",
-                len_expr
+                "            std::slice::from_raw_parts(self.raw as *const u8, self.wire_len())",
             )?;
             writeln!(out, "        }}")?;
             writeln!(out, "    }}")?;
@@ -696,7 +690,7 @@ impl CodeGen {
         writeln!(out)?;
         writeln!(out, "{}fn wire_len(&self) -> usize {{", cg::ind(1))?;
         if is_xge {
-            writeln!(out, "{}self.length() as usize", cg::ind(2))?;
+            writeln!(out, "{}32 + 4 * self.length() as usize", cg::ind(2))?;
         } else {
             writeln!(out, "{}32usize", cg::ind(2))?;
         }

--- a/build/cg/request.rs
+++ b/build/cg/request.rs
@@ -318,6 +318,11 @@ impl CodeGen {
         writeln!(out, "    fn wire_ptr(&self) -> *const u8 {{")?;
         writeln!(out, "        self.raw")?;
         writeln!(out, "    }}")?;
+        writeln!(out)?;
+        // reply length field is expressed in 4 bytes units and start after the 32 bytes reply body
+        writeln!(out, "    fn wire_len(&self) -> usize {{")?;
+        writeln!(out, "        (32 + self.length() * 4) as _")?;
+        writeln!(out, "    }}")?;
 
         for f in &reply.fields {
             if let Field::Field {
@@ -442,11 +447,14 @@ impl CodeGen {
         Ok(())
     }
 
-    fn emit_reply_fds<O: Write>(&self, out: &mut O, reply_rs_typ: &str, fields: &[Field]) -> io::Result<()> {
+    fn emit_reply_fds<O: Write>(
+        &self,
+        out: &mut O,
+        reply_rs_typ: &str,
+        fields: &[Field],
+    ) -> io::Result<()> {
         // We emit the reply fds.
-        // The offset of 32 + 4 * length correspond to what the C implementation is doing.
-        //  - 32 is in fact sizeof(reply_t), which is always 32 the replies that receive fd
-        //  - 4 * length means that it is after the overall length (length is in units of 4 bytes)
+        // libxcb store them after the wire body.
         for f in fields {
             match f {
                 Field::Field { name, rs_typ, .. } if rs_typ == "RawFd" => {
@@ -462,7 +470,7 @@ impl CodeGen {
                     )?;
                     writeln!(
                         out,
-                        "{}*(self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd)",
+                        "{}*(self.wire_ptr().add(self.wire_len()) as *const RawFd)",
                         cg::ind(3)
                     )?;
                     writeln!(out, "{}}}", cg::ind(2))?;
@@ -475,7 +483,7 @@ impl CodeGen {
                     writeln!(out, "{}let len = self.nfd() as usize;", cg::ind(3))?;
                     writeln!(
                         out,
-                        "{}let ptr = self.wire_ptr().add((32 + 4 * self.length()) as _) as *const RawFd;",
+                        "{}let ptr = self.wire_ptr().add(self.wire_len()) as *const RawFd;",
                         cg::ind(3)
                     )?;
                     writeln!(out, "{}std::slice::from_raw_parts(ptr, len)", cg::ind(3))?;

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1984,8 +1984,8 @@ impl CodeGen {
                         cg::ind(3),
                         self.build_rs_expr(wire_off, "self.", "()", fields)
                     )?;
-                    writeln!(out, "{}assert_eq!((self.length() as usize - offset) % std::mem::size_of::<{}>(), 0);", cg::ind(3), q_rs_typ)?;
-                    writeln!(out, "{}let len = (self.length() as usize - offset) / std::mem::size_of::<{}>();", cg::ind(3), q_rs_typ)?;
+                    writeln!(out, "{}assert_eq!((self.wire_len() as usize - offset) % std::mem::size_of::<{}>(), 0);", cg::ind(3), q_rs_typ)?;
+                    writeln!(out, "{}let len = (self.wire_len() as usize - offset) / std::mem::size_of::<{}>();", cg::ind(3), q_rs_typ)?;
                     writeln!(out, "{}std::slice::from_raw_parts(self.wire_ptr().add(offset) as *const {}, len)", cg::ind(3), q_rs_typ)?;
                     writeln!(out, "{}}}", cg::ind(2))?;
                     writeln!(out, "{}}}", cg::ind(1))?;


### PR DESCRIPTION
In replies and in XGE events, the length field is in 4 bytes units, and starts after the 32 bytes main body.