### PR TITLE
Do not perform UTF-8 conversions

### DIFF
--- a/build/cg/request.rs
+++ b/build/cg/request.rs
@@ -649,7 +649,7 @@ impl CodeGen {
                     if let Some(doc) = doc {
                         doc.emit(out, 1)?;
                     }
-                    writeln!(out, "    pub {}: &'a str,", name)?;
+                    writeln!(out, "    pub {}: &'a [u8],", name)?;
                 }
                 Field::List {
                     name,

--- a/build/cg/switch.rs
+++ b/build/cg/switch.rs
@@ -1124,8 +1124,9 @@ impl CodeGen {
                     Field::List { name, rs_typ, .. } if rs_typ == "char" => {
                         writeln!(
                             out,
-                            "{}(&mut wire_buf[offset..]).copy_from_slice({}.as_bytes());",
+                            "{}(&mut wire_buf[offset..offset+{}.len()]).copy_from_slice({}.as_bytes());",
                             cg::ind(ind + 2),
+                            name,
                             name
                         )?;
                         writeln!(out, "{}offset += {}.len();", cg::ind(ind + 2), name)?;

--- a/examples/basic_window.rs
+++ b/examples/basic_window.rs
@@ -1,4 +1,3 @@
-use std::str;
 use xcb::{x, Xid};
 
 fn main() -> xcb::Result<()> {
@@ -53,30 +52,30 @@ fn main() -> xcb::Result<()> {
         long_length: 1024,
     });
     let reply = conn.wait_for_reply(cookie)?;
-    assert_eq!(str::from_utf8(reply.value()).unwrap(), title);
+    assert_eq!(reply.value::<u8>(), title.as_bytes());
 
     // retrieving a few atoms
     let (wm_protocols, wm_del_window, wm_state, wm_state_maxv, wm_state_maxh) = {
         let cookies = (
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "WM_PROTOCOLS",
+                name: b"WM_PROTOCOLS",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "WM_DELETE_WINDOW",
+                name: b"WM_DELETE_WINDOW",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "_NET_WM_STATE",
+                name: b"_NET_WM_STATE",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "_NET_WM_STATE_MAXIMIZED_VERT",
+                name: b"_NET_WM_STATE_MAXIMIZED_VERT",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "_NET_WM_STATE_MAXIMIZED_HORZ",
+                name: b"_NET_WM_STATE_MAXIMIZED_HORZ",
             }),
         );
         (

--- a/examples/opengl_window.rs
+++ b/examples/opengl_window.rs
@@ -129,11 +129,11 @@ fn main() -> xcb::Result<()> {
         let cookies = (
             conn.send_request(&x::InternAtom {
                 only_if_exists: false,
-                name: "WM_PROTOCOLS",
+                name: b"WM_PROTOCOLS",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: false,
-                name: "WM_DELETE_WINDOW",
+                name: b"WM_DELETE_WINDOW",
             }),
         );
         (

--- a/examples/xinput_stylus_events.rs
+++ b/examples/xinput_stylus_events.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::str;
 use xcb::{x, xinput};
 
 #[derive(Debug)]
@@ -49,7 +50,7 @@ fn main() -> xcb::Result<()> {
     let device = {
         let mut device: Option<StylusDevice> = None;
         for (i, dev) in device_list.devices().iter().enumerate() {
-            let name = device_list.names().nth(i).unwrap().name().unwrap();
+            let name = str::from_utf8(device_list.names().nth(i).unwrap().name()).unwrap();
             if name.contains(&find_device) {
                 device = Some(StylusDevice {
                     id: dev.device_id() as xinput::DeviceId,

--- a/src/base.rs
+++ b/src/base.rs
@@ -1333,7 +1333,7 @@ impl Connection {
     ///     // Example of request with reply. The error (if any) is obtained with the reply.
     ///     let cookie = conn.send_request(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: x::Atom = conn
     ///             .wait_for_reply(cookie)?
@@ -1384,7 +1384,7 @@ impl Connection {
     /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
     ///     let cookie = conn.send_request_unchecked(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: Option<x::Atom> = conn
     ///             .wait_for_reply_unchecked(cookie)?
@@ -1445,7 +1445,7 @@ impl Connection {
     /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
     ///     let cookie = conn.send_request(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: x::Atom = conn
     ///             .wait_for_reply(cookie)?
@@ -1486,7 +1486,7 @@ impl Connection {
     /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
     ///     let cookie = conn.send_request_unchecked(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: Option<x::Atom> = conn
     ///             .wait_for_reply_unchecked(cookie)?  // connection error may happen
@@ -1570,6 +1570,7 @@ mod dan {
     use std::fmt;
     use std::mem;
     use std::ptr;
+    use std::str;
 
     pub(crate) static mut DAN_CONN: *mut xcb_connection_t = ptr::null_mut();
 
@@ -1592,7 +1593,7 @@ mod dan {
                     fmt::Error
                 })?;
 
-                let name = reply.name().map_err(|err| {
+                let name = str::from_utf8(reply.name()).map_err(|err| {
                     eprintln!(
                         "Non UTF-8 name received for x::Atom {}: {:#?}",
                         self.resource_id(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,23 +132,23 @@
 //!         let cookies = (
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "WM_PROTOCOLS",
+//!                 name: b"WM_PROTOCOLS",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "WM_DELETE_WINDOW",
+//!                 name: b"WM_DELETE_WINDOW",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "_NET_WM_STATE",
+//!                 name: b"_NET_WM_STATE",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "_NET_WM_STATE_MAXIMIZED_VERT",
+//!                 name: b"_NET_WM_STATE_MAXIMIZED_VERT",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "_NET_WM_STATE_MAXIMIZED_HORZ",
+//!                 name: b"_NET_WM_STATE_MAXIMIZED_HORZ",
 //!             }),
 //!         );
 //!         (

--- a/xml/xproto.xml
+++ b/xml/xproto.xml
@@ -2900,7 +2900,7 @@ not yet exist.
 // Resolve the _NET_WM_NAME atom.
 let cookie = conn.send_request(&x::InternAtom {
     only_if_exists: false,
-    name: "_NET_WM_NAME",
+    name: b"_NET_WM_NAME",
 });
 let reply = conn.wait_for_reply(cookie)?;
 let wm_name = reply.atom();


### PR DESCRIPTION
All strings are treated as bytes.
Rationale: X protocol specifies that strings are latin1 encoded.