### PR TITLE
Do not perform UTF-8 conversions

### DIFF
--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -472,6 +472,10 @@ impl CodeGen {
         writeln!(out, "use crate::ext;")?;
         writeln!(out, "use crate::ffi::base::*;")?;
         writeln!(out, "use crate::ffi::ext::*;")?;
+        writeln!(
+            out,
+            "use crate::lat1_str::{{Lat1Str, Lat1String, Lat1StrF}};"
+        )?;
         for di in &self.depinfo {
             writeln!(out, "use crate::{};", di.xcb_mod)?;
         }

--- a/build/cg/request.rs
+++ b/build/cg/request.rs
@@ -649,7 +649,7 @@ impl CodeGen {
                     if let Some(doc) = doc {
                         doc.emit(out, 1)?;
                     }
-                    writeln!(out, "    pub {}: &'a str,", name)?;
+                    writeln!(out, "    pub {}: &'a [u8],", name)?;
                 }
                 Field::List {
                     name,

--- a/build/cg/switch.rs
+++ b/build/cg/switch.rs
@@ -215,7 +215,7 @@ impl CodeGen {
                         writeln!(out, "    {}({}),", c.name, q_rs_typ)?;
                     }
                     Field::List { rs_typ, .. } if rs_typ == "char" => {
-                        writeln!(out, "    {}(String),", c.name)?;
+                        writeln!(out, "    {}(Lat1String),", c.name)?;
                     }
                     Field::List {
                         r#enum: Some(r#enum),
@@ -288,7 +288,7 @@ impl CodeGen {
                             }
                         }
                         Field::List { name, rs_typ, .. } if rs_typ == "char" => {
-                            writeln!(out, "        {}: String,", name)?;
+                            writeln!(out, "        {}: Lat1String,", name)?;
                         }
                         Field::List {
                             name,
@@ -508,8 +508,13 @@ impl CodeGen {
                             name,
                             len_expr,
                         )?;
-                        writeln!(out, "{}let {} = std::str::from_utf8({}_bytes).expect(\"Invalid UTF-8 for {}::{}\");", cg::ind(3), name, name, rs_typ, name)?;
-                        writeln!(out, "{}let {} = String::from({});", cg::ind(3), name, name)?;
+                        writeln!(
+                            out,
+                            "{}let {} = Lat1String::from_bytes({}_bytes);",
+                            cg::ind(3),
+                            name,
+                            name
+                        )?;
                         writeln!(out, "{}offset += {}.len();", cg::ind(3), name)?;
                     }
                     Field::List {
@@ -1124,8 +1129,9 @@ impl CodeGen {
                     Field::List { name, rs_typ, .. } if rs_typ == "char" => {
                         writeln!(
                             out,
-                            "{}(&mut wire_buf[offset..]).copy_from_slice({}.as_bytes());",
+                            "{}(&mut wire_buf[offset..offset+{}.len()]).copy_from_slice({}.as_bytes());",
                             cg::ind(ind + 2),
+                            name,
                             name
                         )?;
                         writeln!(out, "{}offset += {}.len();", cg::ind(ind + 2), name)?;

--- a/examples/basic_window.rs
+++ b/examples/basic_window.rs
@@ -1,4 +1,3 @@
-use std::str;
 use xcb::{x, Xid};
 
 fn main() -> xcb::Result<()> {
@@ -53,30 +52,30 @@ fn main() -> xcb::Result<()> {
         long_length: 1024,
     });
     let reply = conn.wait_for_reply(cookie)?;
-    assert_eq!(str::from_utf8(reply.value()).unwrap(), title);
+    assert_eq!(reply.value::<u8>(), title.as_bytes());
 
     // retrieving a few atoms
     let (wm_protocols, wm_del_window, wm_state, wm_state_maxv, wm_state_maxh) = {
         let cookies = (
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "WM_PROTOCOLS",
+                name: b"WM_PROTOCOLS",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "WM_DELETE_WINDOW",
+                name: b"WM_DELETE_WINDOW",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "_NET_WM_STATE",
+                name: b"_NET_WM_STATE",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "_NET_WM_STATE_MAXIMIZED_VERT",
+                name: b"_NET_WM_STATE_MAXIMIZED_VERT",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: true,
-                name: "_NET_WM_STATE_MAXIMIZED_HORZ",
+                name: b"_NET_WM_STATE_MAXIMIZED_HORZ",
             }),
         );
         (

--- a/examples/opengl_window.rs
+++ b/examples/opengl_window.rs
@@ -129,11 +129,11 @@ fn main() -> xcb::Result<()> {
         let cookies = (
             conn.send_request(&x::InternAtom {
                 only_if_exists: false,
-                name: "WM_PROTOCOLS",
+                name: b"WM_PROTOCOLS",
             }),
             conn.send_request(&x::InternAtom {
                 only_if_exists: false,
-                name: "WM_DELETE_WINDOW",
+                name: b"WM_DELETE_WINDOW",
             }),
         );
         (

--- a/examples/xinput_stylus_events.rs
+++ b/examples/xinput_stylus_events.rs
@@ -49,7 +49,7 @@ fn main() -> xcb::Result<()> {
     let device = {
         let mut device: Option<StylusDevice> = None;
         for (i, dev) in device_list.devices().iter().enumerate() {
-            let name = device_list.names().nth(i).unwrap().name().unwrap();
+            let name = device_list.names().nth(i).unwrap().name().to_utf8();
             if name.contains(&find_device) {
                 device = Some(StylusDevice {
                     id: dev.device_id() as xinput::DeviceId,

--- a/src/base.rs
+++ b/src/base.rs
@@ -1333,7 +1333,7 @@ impl Connection {
     ///     // Example of request with reply. The error (if any) is obtained with the reply.
     ///     let cookie = conn.send_request(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: x::Atom = conn
     ///             .wait_for_reply(cookie)?
@@ -1384,7 +1384,7 @@ impl Connection {
     /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
     ///     let cookie = conn.send_request_unchecked(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: Option<x::Atom> = conn
     ///             .wait_for_reply_unchecked(cookie)?
@@ -1445,7 +1445,7 @@ impl Connection {
     /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
     ///     let cookie = conn.send_request(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: x::Atom = conn
     ///             .wait_for_reply(cookie)?
@@ -1486,7 +1486,7 @@ impl Connection {
     /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
     ///     let cookie = conn.send_request_unchecked(&x::InternAtom {
     ///         only_if_exists: true,
-    ///         name: "WM_PROTOCOLS",
+    ///         name: b"WM_PROTOCOLS",
     ///     });
     ///     let wm_protocols_atom: Option<x::Atom> = conn
     ///             .wait_for_reply_unchecked(cookie)?  // connection error may happen
@@ -1570,6 +1570,7 @@ mod dan {
     use std::fmt;
     use std::mem;
     use std::ptr;
+    use std::str;
 
     pub(crate) static mut DAN_CONN: *mut xcb_connection_t = ptr::null_mut();
 
@@ -1592,16 +1593,8 @@ mod dan {
                     fmt::Error
                 })?;
 
-                let name = reply.name().map_err(|err| {
-                    eprintln!(
-                        "Non UTF-8 name received for x::Atom {}: {:#?}",
-                        self.resource_id(),
-                        err
-                    );
-                    fmt::Error
-                })?;
-
-                write(name)?;
+                let name = reply.name().to_utf8();
+                write(&name)?;
 
                 mem::forget(conn);
                 Ok(())

--- a/src/lat1_str.rs
+++ b/src/lat1_str.rs
@@ -1,0 +1,258 @@
+use std::borrow::Cow;
+use std::fmt;
+use std::str;
+
+/// Error that can produce Latin-1 string operations
+#[derive(Debug, Copy, Clone)]
+pub enum Lat1Error {
+    /// Some non-ASCII characters were encountered.
+    /// This error is generated when attempting to borrow
+    /// a latin-1 string out of a UTF-8 string.
+    /// For such borrow, only the ASCII character set is allowed.
+    /// See [Lat1Str::try_from_ascii].
+    NonAscii,
+}
+
+/// A slice to a Latin-1 (aka. ISO 8859-1) string.
+///
+/// It is usually seen in its borrowed form, `&Lat1Str`.
+/// Lat1Str contains a slice of bytes and is by definition always
+/// valid Latin-1.
+///
+/// This type is useful for XCB because strings in the X protocol are
+/// expected to be Latin-1 encoded.
+/// Although the X strings are Latin-1, in reality ASCII can be
+/// expected without too much risk, hence all the ASCII related functions.
+///
+/// This does not account for strings passed as raw bytes
+/// to [x::ChangeProperty](crate::x::ChangeProperty) (e.g. to set a window title).
+/// These strings are passed as-is by the X server to the window compositor and
+/// encoding is implied by the property itself
+/// (e.g. UTF-8 for `_NET_WM_NAME` aka. window title).
+pub struct Lat1Str {
+    data: [u8],
+}
+
+impl Lat1Str {
+    /// Returns a reference to a Lat1Str that borrows the passed bytes
+    pub fn from_bytes(bytes: &[u8]) -> &Self {
+        unsafe { &*(bytes as *const [u8] as *const Self) }
+    }
+
+    /// Returns a reference to a `Lat1Str` that borrows the passed string bytes
+    /// only if `str` is pure ASCII.
+    /// Otherwise, a `Lat1Error::NonAscii` is returned.
+    pub fn try_from_ascii(str: &str) -> Result<&Self, Lat1Error> {
+        if str.is_ascii() {
+            Ok(Self::from_bytes(str.as_bytes()))
+        } else {
+            Err(Lat1Error::NonAscii)
+        }
+    }
+
+    /// Returns a reference to a `Lat1Str` that borrows the passed string bytes
+    /// only if `str` is pure ASCII.
+    ///
+    /// # Panics
+    /// This function panics if `str` contains non-ASCII chars.
+    pub fn from_ascii(str: &str) -> &Self {
+        Self::try_from_ascii(str).unwrap()
+    }
+
+    /// Returns a reference to a `Lat1Str` that borrows the passed string bytes.
+    ///
+    /// # Safety
+    /// If `str` contains non-ASCII characters, the returned string will not correspond
+    /// to the passed string (the latin-1 will contain utf-8 encoding).
+    pub unsafe fn from_ascii_unchecked(str: &str) -> &Self {
+        Self::from_bytes(str.as_bytes())
+    }
+
+    /// Returns a Latin-1 string built from a UTF-8 string
+    ///
+    /// `Cow::Borrowed` is returned if `str` contains only ASCII,
+    /// otherwise, a conversion from UTF-8 is performed and `Cow::Owned` is returned.
+    pub fn from_utf8(str: &str) -> Cow<Lat1Str> {
+        if str.is_ascii() {
+            Cow::Borrowed(Lat1Str::from_bytes(str.as_bytes()))
+        } else {
+            Cow::Owned(Lat1String::from_utf8(str))
+        }
+    }
+
+    /// Checks whether the slice only contains ASCII characters.
+    pub fn is_ascii(&self) -> bool {
+        self.data.is_ascii()
+    }
+
+    /// Returns the number of characters in the string.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns the string as slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Returns the string in UTF-8 encoding, only if the string is pure ASCII.
+    /// Otherwise, a `Lat1Error::NonAscii` is returned.
+    pub fn try_as_ascii(&self) -> Result<&str, Lat1Error> {
+        if self.is_ascii() {
+            Ok(unsafe { str::from_utf8_unchecked(&self.data) })
+        } else {
+            Err(Lat1Error::NonAscii)
+        }
+    }
+
+    /// Returns the string in UTF-8 encoding, only if the string is pure ASCII.
+    ///
+    /// # Panics
+    /// This function panics if the string contains non-ASCII chars.
+    pub fn as_ascii(&self) -> &str {
+        self.try_as_ascii().unwrap()
+    }
+
+    /// Returns the string in UTF-8 encoding.
+    ///
+    /// # Safety
+    /// If the string contains non-ASCII characters, the returned string will be
+    /// invalid UTF-8.
+    pub unsafe fn as_ascii_unchecked(&self) -> &str {
+        str::from_utf8_unchecked(&self.data)
+    }
+
+    /// Returns the string converted to UTF-8.
+    ///
+    /// `Cow::Borrowed` is returned if the string is pure ASCII,
+    /// otherwise a conversion to UTF-8 is performed and `Cow::Owned` is returned.
+    pub fn to_utf8(&self) -> Cow<str> {
+        if self.is_ascii() {
+            Cow::Borrowed(unsafe { self.as_ascii_unchecked() })
+        } else {
+            Cow::Owned(self.data.iter().map(|c| *c as char).collect())
+        }
+    }
+}
+
+impl std::borrow::ToOwned for Lat1Str {
+    type Owned = Lat1String;
+    fn to_owned(&self) -> Self::Owned {
+        Lat1String {
+            data: self.as_bytes().to_vec(),
+        }
+    }
+}
+
+impl fmt::Display for Lat1Str {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_utf8();
+        f.write_str(&s)
+    }
+}
+
+impl fmt::Debug for Lat1Str {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_utf8();
+        f.write_fmt(format_args!("Lat1(\"{}\")", s))
+    }
+}
+
+/// A struct owning a Latin-1 (aka. ISO 8859-1) string.
+///
+/// See [Lat1Str] for details.
+#[derive(Clone)]
+pub struct Lat1String {
+    data: Vec<u8>,
+}
+
+impl Lat1String {
+    /// Construct a [Lat1String] from a slice of bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        Lat1String {
+            data: bytes.to_vec(),
+        }
+    }
+
+    /// Construct a [Lat1String] from UTF-8 (a conversion to Latin-1 is performed).
+    pub fn from_utf8(str: &str) -> Self {
+        Lat1String {
+            data: str.chars().map(|c| c as u8).collect(),
+        }
+    }
+}
+
+impl std::ops::Deref for Lat1String {
+    type Target = Lat1Str;
+    fn deref(&self) -> &Self::Target {
+        Lat1Str::from_bytes(self.data.as_slice())
+    }
+}
+
+impl std::borrow::Borrow<Lat1Str> for Lat1String {
+    fn borrow(&self) -> &Lat1Str {
+        Lat1Str::from_bytes(self.data.as_slice())
+    }
+}
+
+impl fmt::Display for Lat1String {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_utf8();
+        f.write_str(&s)
+    }
+}
+
+impl fmt::Debug for Lat1String {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_utf8();
+        f.write_fmt(format_args!("Lat1(\"{}\")", s))
+    }
+}
+
+#[derive(Copy, Clone)]
+/// Latin-1 (aka. ISO 8859-1) of fixed size
+pub struct Lat1StrF<const N: usize> {
+    data: [u8; N],
+}
+
+impl<const N: usize> Lat1StrF<N> {
+    pub fn from_bytes(bytes: [u8; N]) -> Self {
+        Self { data: bytes }
+    }
+}
+
+impl<const N: usize> std::ops::Deref for Lat1StrF<N> {
+    type Target = Lat1Str;
+    fn deref(&self) -> &Self::Target {
+        Lat1Str::from_bytes(self.data.as_slice())
+    }
+}
+
+impl<const N: usize> fmt::Display for Lat1StrF<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_utf8();
+        f.write_str(&s)
+    }
+}
+
+impl<const N: usize> fmt::Debug for Lat1StrF<N> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.to_utf8();
+        f.write_fmt(format_args!("Lat1(\"{}\")", s))
+    }
+}
+
+#[test]
+fn test_latin_str() {
+    let utf8 = "Mon frère est là.";
+    let latin1: &[u8] = &[
+        0x4D, 0x6F, 0x6E, 0x20, 0x66, 0x72, 0xE8, 0x72, 0x65, 0x20, 0x65, 0x73, 0x74, 0x20, 0x6C,
+        0xE0, 0x2E,
+    ];
+
+    let ls = Lat1String::from_utf8(utf8);
+    assert_eq!(ls.as_bytes(), latin1);
+
+    let ls = Lat1Str::from_bytes(latin1);
+    assert_eq!(ls.to_utf8(), utf8);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,23 +132,23 @@
 //!         let cookies = (
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "WM_PROTOCOLS",
+//!                 name: b"WM_PROTOCOLS",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "WM_DELETE_WINDOW",
+//!                 name: b"WM_DELETE_WINDOW",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "_NET_WM_STATE",
+//!                 name: b"_NET_WM_STATE",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "_NET_WM_STATE_MAXIMIZED_VERT",
+//!                 name: b"_NET_WM_STATE_MAXIMIZED_VERT",
 //!             }),
 //!             conn.send_request(&x::InternAtom {
 //!                 only_if_exists: true,
-//!                 name: "_NET_WM_STATE_MAXIMIZED_HORZ",
+//!                 name: b"_NET_WM_STATE_MAXIMIZED_HORZ",
 //!             }),
 //!         );
 //!         (
@@ -300,11 +300,13 @@ mod base;
 mod error;
 mod event;
 mod ext;
+mod lat1_str;
 
 pub use base::*;
 pub use error::*;
 pub use event::*;
 pub use ext::*;
+pub use lat1_str::*;
 
 pub mod x {
     //! The core X protocol definitions

--- a/xml/xproto.xml
+++ b/xml/xproto.xml
@@ -2900,7 +2900,7 @@ not yet exist.
 // Resolve the _NET_WM_NAME atom.
 let cookie = conn.send_request(&x::InternAtom {
     only_if_exists: false,
-    name: "_NET_WM_NAME",
+    name: b"_NET_WM_NAME",
 });
 let reply = conn.wait_for_reply(cookie)?;
 let wm_name = reply.atom();


### PR DESCRIPTION
rationale: X protocol specifies that strings are latin1 encoded