### PR TITLE
Implement std::error::Error for xcb::ProtocolError and xcb::Error

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -579,6 +579,24 @@ pub enum Error {
     Protocol(ProtocolError),
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Connection(_) => f.write_str("xcb connection error"),
+            Error::Protocol(_) => f.write_str("xcb protocol error"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Connection(err) => Some(err),
+            Error::Protocol(err) => Some(err),
+        }
+    }
+}
+
 impl From<ConnError> for Error {
     fn from(err: ConnError) -> Error {
         Error::Connection(err)

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,14 @@ pub enum ProtocolError {
     Xv(xv::Error, Option<&'static str>),
 }
 
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for ProtocolError {}
+
 pub(crate) unsafe fn resolve_error(
     error: *mut xcb_generic_error_t,
     extension_data: &[ExtensionData],


### PR DESCRIPTION
Hi, this is a very basic implementation, it just reuses the Debug print of ProtocolError as the Display print, I don't know if xcb has some mechanism to turn the error codes into human readable messages but considering that Display doesn't have any stability guarantees and the ergonomic improvements of working with errors implementing std::error::Error I think this is better than nothing.