### PR TITLE
Don't panic for unknown events in xproto

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -163,7 +163,7 @@ pub trait ResolveWireEvent: Sized {
     /// # Safety
     /// `event` must be a valid, non-null event returned by `xcb_wait_for_event`
     /// or similar function
-    unsafe fn resolve_wire_event(first_event: u8, event: *mut xcb_generic_event_t) -> Self;
+    unsafe fn resolve_wire_event(first_event: u8, event: *mut xcb_generic_event_t) -> Option<Self>;
 }
 
 /// Trait for the resolution of raw wire GE_GENERIC event to a unified event enum.

--- a/src/event.rs
+++ b/src/event.rs
@@ -108,20 +108,20 @@ pub enum Event {
     Xv(xv::Event),
 
     /// The event was not recognized, it was likely issued from a disabled extension.
-    Unresolved(UnresolvedEvent),
+    Unknown(UnknownEvent),
 }
 
 /// an event was not recognized as part of the core protocol or any enabled extension
-pub struct UnresolvedEvent {
+pub struct UnknownEvent {
     raw: *mut xcb_generic_event_t,
 }
 
-impl BaseEvent for UnresolvedEvent {
+impl BaseEvent for UnknownEvent {
     const EXTENSION: Option<Extension> = None;
     const NUMBER: u32 = u32::MAX;
 
     unsafe fn from_raw(raw: *mut xcb_generic_event_t) -> Self {
-        UnresolvedEvent { raw }
+        UnknownEvent { raw }
     }
 
     unsafe fn into_raw(self) -> *mut xcb_generic_event_t {
@@ -139,13 +139,13 @@ impl BaseEvent for UnresolvedEvent {
     }
 }
 
-impl std::fmt::Debug for UnresolvedEvent {
+impl std::fmt::Debug for UnknownEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("UnresolvedEvent").finish()
+        f.debug_tuple("UnknownEvent").finish()
     }
 }
 
-impl Drop for UnresolvedEvent {
+impl Drop for UnknownEvent {
     fn drop(&mut self) {
         unsafe { libc::free(self.raw as *mut _) }
     }
@@ -285,5 +285,5 @@ pub(crate) unsafe fn resolve_event(
 
     x::Event::resolve_wire_event(0, event)
         .map(Event::X)
-        .unwrap_or_else(|| Event::Unresolved(UnresolvedEvent { raw: event }))
+        .unwrap_or_else(|| Event::Unknown(UnknownEvent { raw: event }))
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -106,6 +106,9 @@ pub enum Event {
     #[cfg(feature = "xv")]
     /// The event is issued from the `XVideo` extension.
     Xv(xv::Event),
+
+    /// The event was not recognized, it was likely issued from a disabled extension.
+    Unknown,
 }
 
 pub(crate) unsafe fn resolve_event(
@@ -139,90 +142,100 @@ pub(crate) unsafe fn resolve_event(
             match data.ext {
                 #[cfg(feature = "damage")]
                 Extension::Damage => {
-                    return Event::Damage(damage::Event::resolve_wire_event(
-                        data.first_event,
-                        event,
-                    ));
+                    return Event::Damage(
+                        damage::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "dri2")]
                 Extension::Dri2 => {
-                    return Event::Dri2(dri2::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Dri2(
+                        dri2::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "glx")]
                 Extension::Glx => {
-                    return Event::Glx(glx::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Glx(
+                        glx::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "present")]
                 Extension::Present => {
-                    return Event::Present(present::Event::resolve_wire_event(
-                        data.first_event,
-                        event,
-                    ));
+                    return Event::Present(
+                        present::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "randr")]
                 Extension::RandR => {
-                    return Event::RandR(randr::Event::resolve_wire_event(data.first_event, event));
+                    return Event::RandR(
+                        randr::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "screensaver")]
                 Extension::ScreenSaver => {
-                    return Event::ScreenSaver(screensaver::Event::resolve_wire_event(
-                        data.first_event,
-                        event,
-                    ));
+                    return Event::ScreenSaver(
+                        screensaver::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "shape")]
                 Extension::Shape => {
-                    return Event::Shape(shape::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Shape(
+                        shape::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "shm")]
                 Extension::Shm => {
-                    return Event::Shm(shm::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Shm(
+                        shm::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "sync")]
                 Extension::Sync => {
-                    return Event::Sync(sync::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Sync(
+                        sync::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "xfixes")]
                 Extension::XFixes => {
-                    return Event::XFixes(xfixes::Event::resolve_wire_event(
-                        data.first_event,
-                        event,
-                    ));
+                    return Event::XFixes(
+                        xfixes::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "xinput")]
                 Extension::Input => {
-                    return Event::Input(xinput::Event::resolve_wire_event(
-                        data.first_event,
-                        event,
-                    ));
+                    return Event::Input(
+                        xinput::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "xkb")]
                 Extension::Xkb => {
-                    return Event::Xkb(xkb::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Xkb(
+                        xkb::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "xprint")]
                 Extension::XPrint => {
-                    return Event::XPrint(xprint::Event::resolve_wire_event(
-                        data.first_event,
-                        event,
-                    ));
+                    return Event::XPrint(
+                        xprint::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 #[cfg(feature = "xv")]
                 Extension::Xv => {
-                    return Event::Xv(xv::Event::resolve_wire_event(data.first_event, event));
+                    return Event::Xv(
+                        xv::Event::resolve_wire_event(data.first_event, event).unwrap(),
+                    );
                 }
 
                 _ => {}
@@ -230,5 +243,7 @@ pub(crate) unsafe fn resolve_event(
         }
     }
 
-    Event::X(x::Event::resolve_wire_event(0, event))
+    x::Event::resolve_wire_event(0, event)
+        .map(Event::X)
+        .unwrap_or(Event::Unknown)
 }


### PR DESCRIPTION
This changes the `ResolveWireEvent::resolve_wire_event` to return an Option. If we assume the X server is not misbihaving it's only possible for the base xproto to get an unparseable event (if the extension the event is from is not currently enabled) so I left the unreachable! in the other ones (and used unwrap on the options in `src/event.rs:resolve_event`).

Closes #141