### PR TITLE
fixing iov_len to correct value for properties

### DIFF
--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -100,6 +100,7 @@ struct SwitchCase {
     fields: Vec<Field>,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug)]
 enum Field {
     Field {

--- a/build/ir.rs
+++ b/build/ir.rs
@@ -63,6 +63,7 @@ pub struct SwitchCase {
     pub fields: Vec<Field>,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub enum Field {
     Pad(usize),


### PR DESCRIPTION
fixes #144

generated code diff:
```diff
diff -ur gen/previous/randr.rs gen/current/randr.rs
--- gen/previous/randr.rs	2022-01-18 21:48:06.491217177 +0100
+++ gen/current/randr.rs	2022-01-18 21:51:43.624233374 +0100
@@ -4919,7 +4919,7 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             sections[4].iov_base = self.data.as_ptr() as *mut _;
-            sections[4].iov_len = self.data.len() * std::mem::size_of::<u8>();
+            sections[4].iov_len = self.data.len() * std::mem::size_of::<P>();
             sections[5].iov_len = base::align_pad(sections[4].iov_len, 4);
 
             let flags = if checked {
@@ -9489,7 +9489,7 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             sections[4].iov_base = self.data.as_ptr() as *mut _;
-            sections[4].iov_len = self.data.len() * std::mem::size_of::<u8>();
+            sections[4].iov_len = self.data.len() * std::mem::size_of::<P>();
             sections[5].iov_len = base::align_pad(sections[4].iov_len, 4);
 
             let flags = if checked {
diff -ur gen/previous/xproto.rs gen/current/xproto.rs
--- gen/previous/xproto.rs	2022-01-18 21:48:09.117916074 +0100
+++ gen/current/xproto.rs	2022-01-18 21:51:46.287607041 +0100
@@ -13172,7 +13172,7 @@
             sections[3].iov_len = base::align_pad(sections[2].iov_len, 4);
 
             sections[4].iov_base = self.data.as_ptr() as *mut _;
-            sections[4].iov_len = self.data.len() * std::mem::size_of::<u8>();
+            sections[4].iov_len = self.data.len() * std::mem::size_of::<P>();
             sections[5].iov_len = base::align_pad(sections[4].iov_len, 4);
 
             let flags = if checked {
```