### PR TITLE
Refactor traits

### DIFF
--- a/build/cg/error.rs
+++ b/build/cg/error.rs
@@ -130,6 +130,23 @@ impl CodeGen {
             writeln!(out, "}}")?;
 
             writeln!(out)?;
+            writeln!(
+                out,
+                "impl base::Raw<xcb_generic_error_t> for {} {{",
+                error.rs_typ
+            )?;
+            writeln!(
+                out,
+                "    unsafe fn from_raw(raw: *mut xcb_generic_error_t) -> Self {{ {} {{ raw }} }}",
+                error.rs_typ
+            )?;
+            writeln!(out)?;
+            writeln!(out, "    fn as_raw(&self) -> *mut xcb_generic_error_t {{")?;
+            writeln!(out, "        self.raw")?;
+            writeln!(out, "    }}")?;
+            writeln!(out, "}}")?;
+
+            writeln!(out)?;
             writeln!(out, "impl base::BaseError for {} {{", error.rs_typ)?;
             if let Some(ext_info) = self.ext_info.as_ref() {
                 writeln!(
@@ -149,25 +166,6 @@ impl CodeGen {
             } else {
                 writeln!(out, "    const NUMBER: u32 = u32::MAX;")?;
             }
-            writeln!(out)?;
-            writeln!(
-                out,
-                "    unsafe fn from_raw(raw: *mut xcb_generic_error_t) -> Self {{ {} {{ raw }} }}",
-                error.rs_typ
-            )?;
-            writeln!(out)?;
-            writeln!(
-                out,
-                "    unsafe fn into_raw(self) -> *mut xcb_generic_error_t {{"
-            )?;
-            writeln!(out, "        let raw = self.raw;")?;
-            writeln!(out, "        std::mem::forget(self);")?;
-            writeln!(out, "        raw")?;
-            writeln!(out, "    }}")?;
-            writeln!(out)?;
-            writeln!(out, "    fn as_raw(&self) -> *mut xcb_generic_error_t {{")?;
-            writeln!(out, "        self.raw")?;
-            writeln!(out, "    }}")?;
             writeln!(out)?;
             writeln!(out, "    fn as_slice(&self) -> &[u8] {{")?;
             writeln!(out, "        unsafe {{")?;

--- a/build/cg/error.rs
+++ b/build/cg/error.rs
@@ -166,16 +166,6 @@ impl CodeGen {
             } else {
                 writeln!(out, "    const NUMBER: u32 = u32::MAX;")?;
             }
-            writeln!(out)?;
-            writeln!(out, "    fn as_slice(&self) -> &[u8] {{")?;
-            writeln!(out, "        unsafe {{")?;
-            writeln!(
-                out,
-                "            std::slice::from_raw_parts(self.raw as *const u8, {})",
-                self.build_rs_expr(&error.wire_sz, "", "", &[])
-            )?;
-            writeln!(out, "        }}")?;
-            writeln!(out, "    }}")?;
             writeln!(out, "}}")?;
 
             writeln!(out)?;

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -288,15 +288,6 @@ impl CodeGen {
                 )?;
             }
             writeln!(out, "    const NUMBER: u32 = {};", event.number)?;
-            writeln!(out)?;
-            writeln!(out, "    fn as_slice(&self) -> &[u8] {{")?;
-            writeln!(out, "        unsafe {{")?;
-            writeln!(
-                out,
-                "            std::slice::from_raw_parts(self.raw as *const u8, self.wire_len())",
-            )?;
-            writeln!(out, "        }}")?;
-            writeln!(out, "    }}")?;
 
             writeln!(out, "}}")?;
 
@@ -737,7 +728,12 @@ impl CodeGen {
         )?;
         writeln!(
             out,
-            "{}(&mut wire_buf[0 .. self.wire_len()]).copy_from_slice(self.as_slice());",
+            "{}let raw_slice = unsafe {{ std::slice::from_raw_parts(self.raw as *const u8, self.wire_len()) }};",
+            cg::ind(2)
+        )?;
+        writeln!(
+            out,
+            "{}(&mut wire_buf[0 .. self.wire_len()]).copy_from_slice(raw_slice);",
             cg::ind(2)
         )?;
         writeln!(out, "{}self.wire_len()", cg::ind(2))?;

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -253,6 +253,20 @@ impl CodeGen {
             writeln!(out, "}}")?;
 
             writeln!(out)?;
+            writeln!(out, "impl base::Raw<{}> for {} {{", raw_typ, event.rs_typ)?;
+            writeln!(
+                out,
+                "    unsafe fn from_raw(raw: *mut {}) -> Self {{ {} {{ raw }} }}",
+                raw_typ, event.rs_typ
+            )?;
+            writeln!(out)?;
+            writeln!(out, "    fn as_raw(&self) -> *mut {} {{", raw_typ)?;
+            writeln!(out, "        self.raw")?;
+            writeln!(out, "    }}")?;
+
+            writeln!(out, "}}")?;
+
+            writeln!(out)?;
             writeln!(out, "impl {} for {} {{", trait_impl, event.rs_typ)?;
             if event.is_xge {
                 writeln!(
@@ -274,23 +288,6 @@ impl CodeGen {
                 )?;
             }
             writeln!(out, "    const NUMBER: u32 = {};", event.number)?;
-            writeln!(out)?;
-            writeln!(
-                out,
-                "    unsafe fn from_raw(raw: *mut {}) -> Self {{ {} {{ raw }} }}",
-                raw_typ, event.rs_typ
-            )?;
-            writeln!(out)?;
-            writeln!(out, "    unsafe fn into_raw(self) -> *mut {} {{", raw_typ)?;
-            writeln!(out, "        let raw = self.raw;")?;
-            writeln!(out, "        std::mem::forget(self);")?;
-            writeln!(out, "        raw")?;
-            writeln!(out, "    }}")?;
-            writeln!(out)?;
-            writeln!(out, "    fn as_raw(&self) -> *mut {} {{", raw_typ)?;
-            writeln!(out, "        self.raw")?;
-            writeln!(out, "    }}")?;
-
             writeln!(out)?;
             writeln!(out, "    fn as_slice(&self) -> &[u8] {{")?;
             writeln!(out, "        unsafe {{")?;

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -690,7 +690,7 @@ impl CodeGen {
 
     fn emit_wired_impl<O: Write>(&self, out: &mut O, rs_typ: &str, is_xge: bool) -> io::Result<()> {
         writeln!(out)?;
-        writeln!(out, "impl base::Wired for {} {{", rs_typ)?;
+        writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         writeln!(out, "    type Params = ();")?;
         writeln!(out)?;
         writeln!(

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -691,22 +691,6 @@ impl CodeGen {
     fn emit_wired_impl<O: Write>(&self, out: &mut O, rs_typ: &str, is_xge: bool) -> io::Result<()> {
         writeln!(out)?;
         writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
-        writeln!(out, "    type Params = ();")?;
-        writeln!(out)?;
-        writeln!(
-            out,
-            "{}unsafe fn compute_wire_len({}ptr: *const u8, _params: ()) -> usize {{",
-            cg::ind(1),
-            if is_xge { "" } else { "_" }
-        )?;
-        if is_xge {
-            writeln!(out, "{}32 + 4 * (*(ptr.add(4) as *const u32) as usize)", cg::ind(2))?;
-        } else {
-            writeln!(out, "{}32", cg::ind(2))?;
-        }
-        writeln!(out, "{}}}", cg::ind(1))?;
-
-        writeln!(out)?;
         writeln!(out, "{}fn wire_len(&self) -> usize {{", cg::ind(1))?;
         if is_xge {
             writeln!(out, "{}32 + 4 * self.length() as usize", cg::ind(2))?;
@@ -737,6 +721,28 @@ impl CodeGen {
             cg::ind(2)
         )?;
         writeln!(out, "{}self.wire_len()", cg::ind(2))?;
+        writeln!(out, "{}}}", cg::ind(1))?;
+        writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        writeln!(out, "    type Params = ();")?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{}unsafe fn compute_wire_len({}ptr: *const u8, _params: ()) -> usize {{",
+            cg::ind(1),
+            if is_xge { "" } else { "_" }
+        )?;
+        if is_xge {
+            writeln!(
+                out,
+                "{}32 + 4 * (*(ptr.add(4) as *const u32) as usize)",
+                cg::ind(2)
+            )?;
+        } else {
+            writeln!(out, "{}32", cg::ind(2))?;
+        }
         writeln!(out, "{}}}", cg::ind(1))?;
         writeln!(out, "}}")?;
         Ok(())

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -700,7 +700,7 @@ impl CodeGen {
             if is_xge { "" } else { "_" }
         )?;
         if is_xge {
-            writeln!(out, "{}*(ptr.add(4) as *const u32) as usize", cg::ind(2))?;
+            writeln!(out, "{}32 + 4 * (*(ptr.add(4) as *const u32) as usize)", cg::ind(2))?;
         } else {
             writeln!(out, "{}32", cg::ind(2))?;
         }

--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -468,7 +468,7 @@ impl CodeGen {
         writeln!(out)?;
         writeln!(
             out,
-            "use crate::base::{{self, BaseError, BaseEvent, GeEvent, Raw, Reply, WiredOut, Xid}};"
+            "use crate::base::{{self, BaseError, BaseEvent, GeEvent, Raw, Reply, WiredIn, WiredOut, Xid}};"
         )?;
         writeln!(out, "use crate::ext;")?;
         writeln!(out, "use crate::ffi::base::*;")?;

--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -468,7 +468,7 @@ impl CodeGen {
         writeln!(out)?;
         writeln!(
             out,
-            "use crate::base::{{self, BaseError, BaseEvent, GeEvent, Reply, Wired, Xid}};"
+            "use crate::base::{{self, BaseError, BaseEvent, GeEvent, Raw, Reply, Wired, Xid}};"
         )?;
         writeln!(out, "use crate::ext;")?;
         writeln!(out, "use crate::ffi::base::*;")?;

--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -468,7 +468,7 @@ impl CodeGen {
         writeln!(out)?;
         writeln!(
             out,
-            "use crate::base::{{self, BaseError, BaseEvent, GeEvent, Raw, Reply, Wired, Xid}};"
+            "use crate::base::{{self, BaseError, BaseEvent, GeEvent, Raw, Reply, WiredOut, Xid}};"
         )?;
         writeln!(out, "use crate::ext;")?;
         writeln!(out, "use crate::ffi::base::*;")?;

--- a/build/cg/request.rs
+++ b/build/cg/request.rs
@@ -949,6 +949,13 @@ impl CodeGen {
                 Field::Field { name, .. } | Field::List { name, .. }
                     if sends_event && name == "event" =>
                 {
+                    writeln!(
+                        out,
+                        "{}let raw_{}_slice = std::slice::from_raw_parts(self.{}.as_raw() as *const u8, 32);",
+                        cg::ind(2),
+                        name,
+                        name
+                    )?;
                     writeln!(out, "{}std::slice::from_raw_parts_mut(", cg::ind(2))?;
                     writeln!(
                         out,
@@ -957,12 +964,7 @@ impl CodeGen {
                         num,
                         offset,
                     )?;
-                    writeln!(
-                        out,
-                        "{}).copy_from_slice(self.{}.as_slice());",
-                        cg::ind(2),
-                        name
-                    )?;
+                    writeln!(out, "{}).copy_from_slice(raw_{}_slice);", cg::ind(2), name)?;
                     offset += 32;
                 }
                 Field::Field {

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -622,13 +622,6 @@ impl CodeGen {
 
         writeln!(out)?;
         writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
-        writeln!(out, "    type Params = ();")?;
-        writeln!(
-            out,
-            "    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {{ {} }}",
-            wire_sz
-        )?;
-        writeln!(out)?;
         writeln!(out, "    fn wire_len(&self) -> usize {{ {} }}", wire_sz)?;
         writeln!(out)?;
         writeln!(
@@ -645,6 +638,16 @@ impl CodeGen {
         writeln!(out, "        wire_buf.copy_from_slice(me);")?;
         writeln!(out, "        {}", wire_sz)?;
         writeln!(out, "    }}")?;
+        writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        writeln!(out, "    type Params = ();")?;
+        writeln!(
+            out,
+            "    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {{ {} }}",
+            wire_sz
+        )?;
         writeln!(out, "}}")?;
 
         Ok(())
@@ -706,13 +709,6 @@ impl CodeGen {
 
         writeln!(out)?;
         writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
-        writeln!(out, "    type Params = ();")?;
-        writeln!(
-            out,
-            "    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {{ {} }}",
-            wire_sz
-        )?;
-        writeln!(out)?;
         writeln!(out, "    fn wire_len(&self) -> usize {{ {} }}", wire_sz)?;
         writeln!(out)?;
         writeln!(
@@ -722,6 +718,16 @@ impl CodeGen {
         writeln!(out, "        wire_buf.copy_from_slice(&self.data);")?;
         writeln!(out, "        self.data.len()")?;
         writeln!(out, "    }}")?;
+        writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        writeln!(out, "    type Params = ();")?;
+        writeln!(
+            out,
+            "    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {{ {} }}",
+            wire_sz
+        )?;
         writeln!(out, "}}")?;
 
         self.emit_debug_impl(out, rs_typ, fields)?;
@@ -784,14 +790,6 @@ impl CodeGen {
 
         writeln!(out)?;
         writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
-        writeln!(out, "    type Params = {};", params_struct.rs_typ())?;
-        self.emit_compute_func(
-            out,
-            "compute_wire_len",
-            params_struct,
-            &compute_wire_len_stmts,
-        )?;
-        writeln!(out)?;
         writeln!(out, "    fn wire_len(&self) -> usize {{ self.data.len() }}")?;
         writeln!(out)?;
         writeln!(
@@ -801,6 +799,17 @@ impl CodeGen {
         writeln!(out, "        wire_buf.copy_from_slice(&self.data);")?;
         writeln!(out, "        self.data.len()")?;
         writeln!(out, "    }}")?;
+        writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        writeln!(out, "    type Params = {};", params_struct.rs_typ())?;
+        self.emit_compute_func(
+            out,
+            "compute_wire_len",
+            params_struct,
+            &compute_wire_len_stmts,
+        )?;
         writeln!(out, "}}")?;
 
         writeln!(out)?;

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -621,7 +621,7 @@ impl CodeGen {
         self.emit_sizeof_test(out, rs_typ, wire_sz)?;
 
         writeln!(out)?;
-        writeln!(out, "impl base::Wired for {} {{", rs_typ)?;
+        writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         writeln!(out, "    type Params = ();")?;
         writeln!(
             out,
@@ -705,7 +705,7 @@ impl CodeGen {
         self.emit_sizeof_test(out, rs_typ, wire_sz)?;
 
         writeln!(out)?;
-        writeln!(out, "impl base::Wired for {} {{", rs_typ)?;
+        writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         writeln!(out, "    type Params = ();")?;
         writeln!(
             out,
@@ -783,7 +783,7 @@ impl CodeGen {
         writeln!(out, "}}")?;
 
         writeln!(out)?;
-        writeln!(out, "impl base::Wired for {} {{", rs_typ)?;
+        writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         writeln!(out, "    type Params = {};", params_struct.rs_typ())?;
         self.emit_compute_func(
             out,

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -9,6 +9,7 @@ use super::{
     TypeInfo, WireSz,
 };
 
+use std::borrow::Cow;
 use std::io::{self, Write};
 
 /// struct of external parameters passed to functions such as compute_len
@@ -648,6 +649,13 @@ impl CodeGen {
             "    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {{ {} }}",
             wire_sz
         )?;
+        writeln!(
+            out,
+            "    unsafe fn unserialize(ptr: *const u8, _params: (), offset: &mut usize) -> Self {{"
+        )?;
+        writeln!(out, "        *offset += {};", wire_sz)?;
+        writeln!(out, "        *(ptr as *const {})", rs_typ)?;
+        writeln!(out, "    }}")?;
         writeln!(out, "}}")?;
 
         Ok(())
@@ -728,6 +736,13 @@ impl CodeGen {
             "    unsafe fn compute_wire_len(_ptr: *const u8, _params: ()) -> usize {{ {} }}",
             wire_sz
         )?;
+        writeln!(
+            out,
+            "    unsafe fn unserialize(ptr: *const u8, _params: (), offset: &mut usize) -> Self {{"
+        )?;
+        writeln!(out, "        *offset += {};", wire_sz)?;
+        writeln!(out, "        *(ptr as *const {})", rs_typ)?;
+        writeln!(out, "    }}")?;
         writeln!(out, "}}")?;
 
         self.emit_debug_impl(out, rs_typ, fields)?;
@@ -765,7 +780,7 @@ impl CodeGen {
         if params_struct.is_none() {
             writeln!(
                 out,
-                "        debug_assert_eq!(data.as_ref().len(), {}::compute_wire_len(data.as_ref().as_ptr(), ()));",
+                "        debug_assert_eq!(data.as_ref().len(), <&{} as base::WiredIn>::compute_wire_len(data.as_ref().as_ptr(), ()));",
                 rs_typ
             )?;
         }
@@ -802,7 +817,7 @@ impl CodeGen {
         writeln!(out, "}}")?;
 
         writeln!(out)?;
-        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        writeln!(out, "impl base::WiredIn for &{} {{", rs_typ)?;
         writeln!(out, "    type Params = {};", params_struct.rs_typ())?;
         self.emit_compute_func(
             out,
@@ -810,6 +825,19 @@ impl CodeGen {
             params_struct,
             &compute_wire_len_stmts,
         )?;
+        writeln!(
+            out,
+            "    unsafe fn unserialize(ptr: *const u8, params: {}, offset: &mut usize) -> Self {{",
+            params_struct.rs_typ(),
+        )?;
+        writeln!(out, "        let sz = Self::compute_wire_len(ptr, params);")?;
+        writeln!(out, "        *offset += sz;")?;
+        writeln!(
+            out,
+            "        let data = std::slice::from_raw_parts(ptr, sz);"
+        )?;
+        writeln!(out, "        {}::from_data(data)", rs_typ)?;
+        writeln!(out, "    }}")?;
         writeln!(out, "}}")?;
 
         writeln!(out)?;
@@ -828,7 +856,7 @@ impl CodeGen {
         if params_struct.is_none() {
             writeln!(
                 out,
-                "        debug_assert_eq!({}::compute_wire_len(data.as_ptr(), ()), data.len());",
+                "        debug_assert_eq!(<&{}>::compute_wire_len(data.as_ptr(), ()), data.len());",
                 rs_typ
             )?;
         }
@@ -837,6 +865,31 @@ impl CodeGen {
 
         self.emit_struct_ctor(out, rs_typ, fields, wire_sz)?;
 
+        writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "impl base::WiredIn for {}Buf {{", rs_typ)?;
+        writeln!(out, "    type Params = {};", params_struct.rs_typ())?;
+        writeln!(
+            out,
+            "    unsafe fn compute_wire_len(ptr: *const u8, params: {}) -> usize {{",
+            params_struct.rs_typ(),
+        )?;
+        writeln!(out, "    <&{}>::compute_wire_len(ptr, params)", rs_typ)?;
+        writeln!(out, "}}")?;
+        writeln!(
+            out,
+            "    unsafe fn unserialize(ptr: *const u8, params: {}, offset: &mut usize) -> Self {{",
+            params_struct.rs_typ(),
+        )?;
+        writeln!(out, "        let sz = Self::compute_wire_len(ptr, params);")?;
+        writeln!(out, "        *offset += sz;")?;
+        writeln!(
+            out,
+            "        let data = std::slice::from_raw_parts(ptr, sz);"
+        )?;
+        writeln!(out, "        {}Buf::from_data(data.to_vec())", rs_typ)?;
+        writeln!(out, "    }}")?;
         writeln!(out, "}}")?;
 
         writeln!(out)?;
@@ -913,7 +966,7 @@ impl CodeGen {
                 );
                 stmts.push(format!("// {}", name));
                 stmts.push(format!(
-                    "sz += {}::compute_wire_len(ptr.add({}sz), {});",
+                    "sz += <&{}>::compute_wire_len(ptr.add({}sz), {});",
                     q_rs_typ, struct_offset, params_expr
                 ));
             }
@@ -966,7 +1019,7 @@ impl CodeGen {
                 );
                 if *is_fieldref {
                     stmts.push(format!(
-                        "    let len = {}::compute_wire_len(ptr.add({}sz), {});",
+                        "    let len = <&{}>::compute_wire_len(ptr.add({}sz), {});",
                         q_rs_typ, struct_offset, params_expr
                     ));
                     stmts.push(format!(
@@ -977,7 +1030,7 @@ impl CodeGen {
                     stmts.push("    sz += len;".to_string());
                 } else {
                     stmts.push(format!(
-                        "    sz += {}::compute_wire_len(ptr.add({}sz), {});",
+                        "    sz += <&{}>::compute_wire_len(ptr.add({}sz), {});",
                         q_rs_typ, struct_offset, params_expr
                     ));
                 }
@@ -1033,7 +1086,7 @@ impl CodeGen {
                 );
                 let q_rs_typ = (module, rs_typ).qualified_rs_typ();
                 let impl_type = if *is_mask {
-                    format!("<&[{}]>", q_rs_typ)
+                    format!("<Vec<{}>>", q_rs_typ)
                 } else {
                     q_rs_typ
                 };
@@ -1673,7 +1726,7 @@ impl CodeGen {
                     if let Some(StructStyle::DynBuf) = struct_style {
                         writeln!(
                             out,
-                            "{}let len = {}::compute_wire_len(self.wire_ptr().add(offset), {});",
+                            "{}let len = <&{}>::compute_wire_len(self.wire_ptr().add(offset), {});",
                             cg::ind(3),
                             q_rs_typ,
                             params_expr
@@ -2139,7 +2192,6 @@ impl CodeGen {
                     module,
                     rs_typ,
                     params_struct,
-                    expr,
                     wire_off,
                     is_mask,
                     doc,
@@ -2148,10 +2200,13 @@ impl CodeGen {
                     if let Some(doc) = doc {
                         doc.emit(out, 1)?;
                     }
-                    let return_typ = if *is_mask {
-                        format!("Vec<{}>", rs_typ)
+                    let (impl_typ, return_typ) = if *is_mask {
+                        (
+                            Cow::from(format!("<Vec<{}>>", rs_typ)),
+                            Cow::from(format!("Vec<{}>", rs_typ)),
+                        )
                     } else {
-                        rs_typ.to_string()
+                        (Cow::from(rs_typ), Cow::from(rs_typ))
                     };
                     writeln!(
                         out,
@@ -2197,16 +2252,14 @@ impl CodeGen {
                         "",
                         "",
                     );
-                    let switch_expr = self.build_rs_expr(expr, "self.", "()", fields);
                     let offset_expr = self.build_rs_expr(wire_off, "self.", "()", fields);
                     writeln!(out, "{}let params = {};", cg::ind(2), params_expr)?;
-                    writeln!(out, "{}let offset = {};", cg::ind(2), offset_expr)?;
-                    writeln!(out, "{}let switch = {};", cg::ind(2), switch_expr)?;
+                    writeln!(out, "{}let mut offset = {};", cg::ind(2), offset_expr)?;
                     writeln!(out, "{}unsafe {{", cg::ind(2))?;
-                    writeln!(out, "{}{}::from_wire_data(", cg::ind(3), rs_typ,)?;
+                    writeln!(out, "{}{}::unserialize(", cg::ind(3), impl_typ)?;
                     writeln!(
                         out,
-                        "{}self.wire_ptr().add(offset), switch, params",
+                        "{}self.wire_ptr().add(offset), params, &mut offset",
                         cg::ind(4),
                     )?;
                     writeln!(out, "{})", cg::ind(3))?;
@@ -2436,17 +2489,13 @@ impl CodeGen {
         writeln!(out, "            None")?;
         writeln!(out, "        }} else {{ unsafe {{")?;
         writeln!(out, "            self.rem -= 1;")?;
+        writeln!(out, "            let mut offset = 0;")?;
         writeln!(
             out,
-            "            let len = {}::compute_wire_len(self.ptr, self.params);",
+            "            let res = <&{}>::unserialize(self.ptr, self.params, &mut offset);",
             rs_typ
         )?;
-        writeln!(
-            out,
-            "            let res = {}::from_data(std::slice::from_raw_parts(self.ptr, len));",
-            rs_typ
-        )?;
-        writeln!(out, "            self.ptr = self.ptr.add(len);")?;
+        writeln!(out, "            self.ptr = self.ptr.add(offset);")?;
         writeln!(out, "            Some(res)")?;
         writeln!(out, "        }}}}")?;
         writeln!(out, "    }}")?;

--- a/build/cg/switch.rs
+++ b/build/cg/switch.rs
@@ -341,9 +341,9 @@ impl CodeGen {
 
         writeln!(out)?;
         if is_mask {
-            writeln!(out, "impl base::Wired for &[{}] {{", rs_typ)?;
+            writeln!(out, "impl base::WiredOut for &[{}] {{", rs_typ)?;
         } else {
-            writeln!(out, "impl base::Wired for {} {{", rs_typ)?;
+            writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         }
         writeln!(out, "    type Params = {};", params_struct.rs_typ)?;
         self.emit_switch_compute_wire_len(out, expr, rs_typ, cases, params_struct, is_mask)?;

--- a/build/cg/switch.rs
+++ b/build/cg/switch.rs
@@ -345,13 +345,21 @@ impl CodeGen {
         } else {
             writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         }
-        writeln!(out, "    type Params = {};", params_struct.rs_typ)?;
-        self.emit_switch_compute_wire_len(out, expr, rs_typ, cases, params_struct, is_mask)?;
-        writeln!(out)?;
         self.emit_switch_wire_len(out, rs_typ, cases, is_mask)?;
         writeln!(out)?;
         self.emit_switch_serialize(out, rs_typ, cases, is_mask)?;
         writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        if is_mask {
+            writeln!(out, "impl base::WiredIn for &[{}] {{", rs_typ)?;
+        } else {
+            writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        }
+        writeln!(out, "    type Params = {};", params_struct.rs_typ)?;
+        self.emit_switch_compute_wire_len(out, expr, rs_typ, cases, params_struct, is_mask)?;
+        writeln!(out, "}}")?;
+
         Ok(())
     }
 

--- a/build/cg/union.rs
+++ b/build/cg/union.rs
@@ -384,15 +384,25 @@ impl CodeGen {
         writeln!(out, "    }}")?;
         writeln!(out, "}}")?;
 
-        writeln!(out)?;
-        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
-        writeln!(out, "    type Params = ();")?;
-        writeln!(out)?;
-        writeln!(
+        if type_field.is_some() {
+            writeln!(out)?;
+            writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+            writeln!(out, "    type Params = ();")?;
+            writeln!(out)?;
+            writeln!(
             out,
             "    unsafe fn compute_wire_len(_ptr: *const u8, _params: Self::Params) -> usize {{ {} }}", wire_sz
         )?;
-        writeln!(out, "}}")?;
+            writeln!(out, "    unsafe fn unserialize(ptr: *const u8, _params: (), offset: &mut usize) -> Self {{")?;
+            writeln!(out, "        let sz = Self::compute_wire_len(ptr, ());")?;
+            writeln!(out, "        *offset += sz;")?;
+            writeln!(
+                out,
+                "        Self::from_data(std::slice::from_raw_parts(ptr, sz))"
+            )?;
+            writeln!(out, "    }}")?;
+            writeln!(out, "}}")?;
+        }
 
         Ok(())
     }

--- a/build/cg/union.rs
+++ b/build/cg/union.rs
@@ -256,13 +256,6 @@ impl CodeGen {
 
         writeln!(out)?;
         writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
-        writeln!(out, "    type Params = ();")?;
-        writeln!(out)?;
-        writeln!(
-            out,
-            "    unsafe fn compute_wire_len(_ptr: *const u8, _params: Self::Params) -> usize {{ {} }}", wire_sz
-        )?;
-        writeln!(out)?;
         writeln!(out, "    fn wire_len(&self) -> usize {{ {} }}", wire_sz)?;
         writeln!(out)?;
         writeln!(
@@ -389,6 +382,16 @@ impl CodeGen {
         writeln!(out, "        }}")?;
         writeln!(out, "        {}", wire_sz)?;
         writeln!(out, "    }}")?;
+        writeln!(out, "}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "impl base::WiredIn for {} {{", rs_typ)?;
+        writeln!(out, "    type Params = ();")?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "    unsafe fn compute_wire_len(_ptr: *const u8, _params: Self::Params) -> usize {{ {} }}", wire_sz
+        )?;
         writeln!(out, "}}")?;
 
         Ok(())

--- a/build/cg/union.rs
+++ b/build/cg/union.rs
@@ -255,7 +255,7 @@ impl CodeGen {
         };
 
         writeln!(out)?;
-        writeln!(out, "impl base::Wired for {} {{", rs_typ)?;
+        writeln!(out, "impl base::WiredOut for {} {{", rs_typ)?;
         writeln!(out, "    type Params = ();")?;
         writeln!(out)?;
         writeln!(

--- a/examples/opengl_window.rs
+++ b/examples/opengl_window.rs
@@ -1,6 +1,6 @@
 use xcb::ffi::xcb_generic_event_t;
 use xcb::{self, dri2, glx, x};
-use xcb::{BaseEvent, Xid};
+use xcb::{Raw, Xid};
 
 use x11::glx::*;
 use x11::xlib;

--- a/src/base.rs
+++ b/src/base.rs
@@ -63,7 +63,7 @@ pub trait Raw<T>: Sized {
 
     /// Convert self into a raw pointer
     ///
-    /// Returned value should be freed with `libc::free` or sent back to [from_raw] to avoid memory leak.
+    /// Returned value should be freed with `libc::free` or sent back to `from_raw` to avoid memory leak.
     fn into_raw(self) -> *mut T {
         let raw = self.as_raw();
         mem::forget(self);

--- a/src/base.rs
+++ b/src/base.rs
@@ -174,7 +174,7 @@ pub(crate) trait ResolveWireError {
 ///
 /// This trait is used internally for requests serialization, or in some accessors
 /// that have to compute the size of some wire data.
-pub(crate) trait Wired {
+pub(crate) trait WiredOut {
     /// type to external context necessary to compute the length
     type Params: Copy;
 
@@ -204,7 +204,7 @@ pub(crate) trait Wired {
 
 macro_rules! impl_wired_simple {
     ($typ:ty) => {
-        impl Wired for $typ {
+        impl WiredOut for $typ {
             type Params = ();
 
             unsafe fn compute_wire_len(_ptr: *const u8, _params: Self::Params) -> usize {
@@ -235,7 +235,7 @@ impl_wired_simple!(i16);
 impl_wired_simple!(i32);
 impl_wired_simple!(f32);
 
-impl<T: Xid> Wired for T {
+impl<T: Xid> WiredOut for T {
     type Params = ();
 
     unsafe fn compute_wire_len(_ptr: *const u8, _params: Self::Params) -> usize {

--- a/src/base.rs
+++ b/src/base.rs
@@ -81,9 +81,6 @@ pub trait BaseEvent: Raw<xcb_generic_event_t> {
 
     /// The number associated to this event
     const NUMBER: u32;
-
-    /// Access to the raw event data
-    fn as_slice(&self) -> &[u8];
 }
 
 /// A trait for GE_GENERIC events
@@ -101,9 +98,6 @@ pub trait GeEvent: Raw<xcb_ge_generic_event_t> {
 
     /// The number associated to this event
     const NUMBER: u32;
-
-    /// Access to the raw event data
-    fn as_slice(&self) -> &[u8];
 }
 
 /// A trait to designate base protocol errors.
@@ -118,9 +112,6 @@ pub trait BaseError: Raw<xcb_generic_error_t> {
 
     /// The number associated to this error
     const NUMBER: u32;
-
-    /// Access to the raw error data
-    fn as_slice(&self) -> &[u8];
 }
 
 /// Trait for the resolution of raw wire event to a unified event enum.

--- a/src/base.rs
+++ b/src/base.rs
@@ -207,7 +207,7 @@ pub trait ResolveWireError {
 ///
 /// This trait is used internally for requests serialization, or in some accessors
 /// that have to compute the size of some wire data.
-pub trait Wired {
+pub(crate) trait Wired {
     /// type to external context necessary to compute the length
     type Params: Copy;
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -63,7 +63,7 @@ pub trait Raw<T>: Sized {
 
     /// Convert self into a raw pointer
     ///
-    /// Returned value should be freed with `libc::free` or sent back to [from_row] to avoid memory leak.
+    /// Returned value should be freed with `libc::free` or sent back to [from_raw] to avoid memory leak.
     fn into_raw(self) -> *mut T {
         let raw = self.as_raw();
         mem::forget(self);

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crate::base::{BaseEvent, ResolveWireEvent, ResolveWireGeEvent};
+use crate::base::{BaseEvent, Raw, ResolveWireEvent, ResolveWireGeEvent};
 use crate::ext::{Extension, ExtensionData};
 use crate::ffi::*;
 use crate::x;
@@ -116,23 +116,19 @@ pub struct UnknownEvent {
     raw: *mut xcb_generic_event_t,
 }
 
-impl BaseEvent for UnknownEvent {
-    const EXTENSION: Option<Extension> = None;
-    const NUMBER: u32 = u32::MAX;
-
+impl Raw<xcb_generic_event_t> for UnknownEvent {
     unsafe fn from_raw(raw: *mut xcb_generic_event_t) -> Self {
         UnknownEvent { raw }
-    }
-
-    unsafe fn into_raw(self) -> *mut xcb_generic_event_t {
-        let raw = self.raw;
-        std::mem::forget(self);
-        raw
     }
 
     fn as_raw(&self) -> *mut xcb_generic_event_t {
         self.raw
     }
+}
+
+impl BaseEvent for UnknownEvent {
+    const EXTENSION: Option<Extension> = None;
+    const NUMBER: u32 = u32::MAX;
 
     fn as_slice(&self) -> &[u8] {
         // All basic event types are 32 bytes

--- a/src/event.rs
+++ b/src/event.rs
@@ -129,11 +129,6 @@ impl Raw<xcb_generic_event_t> for UnknownEvent {
 impl BaseEvent for UnknownEvent {
     const EXTENSION: Option<Extension> = None;
     const NUMBER: u32 = u32::MAX;
-
-    fn as_slice(&self) -> &[u8] {
-        // All basic event types are 32 bytes
-        unsafe { std::slice::from_raw_parts(self.raw as *const u8, 32) }
-    }
 }
 
 impl std::fmt::Debug for UnknownEvent {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::base::{self, Wired};
+use crate::base::{self, WiredOut};
 use crate::x;
 
 fn visual_data(bits_per_rgb_value: u8) -> Vec<u8> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::base::{self, WiredOut};
+use crate::base::{self, WiredOut, WiredIn};
 use crate::x;
 
 fn visual_data(bits_per_rgb_value: u8) -> Vec<u8> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -71,7 +71,10 @@ fn test_dynbuf_from_data() {
     let mut data = depth_data(&[32, 24], 4);
 
     assert_eq!(data.len(), 60);
-    assert_eq!(unsafe { x::Depth::compute_wire_len(data.as_ptr(), ()) }, 56);
+    assert_eq!(
+        unsafe { <&x::Depth as WiredIn>::compute_wire_len(data.as_ptr(), ()) },
+        56
+    );
     {
         let depth = unsafe { x::Depth::from_data(&data[0..56]) };
         assert_eq!(depth.depth(), 16);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::base::{self, WiredOut, WiredIn};
+use crate::base::{self, WiredIn, WiredOut};
 use crate::x;
 
 fn visual_data(bits_per_rgb_value: u8) -> Vec<u8> {


### PR DESCRIPTION
Refactor a few traits:
 - [x] Make private what is not meant to be used by end user.
 - [x] Simplify a few things (like removing `BaseEvent::as_slice`)
 - [x] Attempt to add `Wired::unserialize`. A little tricky as `Wired` is often implemented for `!Sized` types.