### PR TITLE
Rustify connection to X Server

### DIFF
--- a/examples/xkb_init.rs
+++ b/examples/xkb_init.rs
@@ -1,7 +1,10 @@
 use xcb::xkb;
 
 fn main() -> xcb::Result<()> {
-    let (conn, _) = xcb::Connection::connect_with_extensions(None, &[xcb::Extension::Xkb], &[])?;
+    // Connect to the xserver using the value on $DISPLAY env variable
+    let (conn, _) = xcb::ConnBuilder::new()
+        .with_extensions(&[xcb::Extension::Xkb])
+        .build()?;
 
     // we need at least xkb-1.0 to be available on client
     // machine


### PR DESCRIPTION
In this case I think that a more idiomatic approach could be better, at the moment is just `connect_*` with many options, also there are some, `from_*`, my suggestion is to use the [builder pattern](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html) and just maintain in the `Connection` struct the `connect`, and the simple `from_*` (Also remaining both ways to interact with the api would be ok)

**My implementation**
```rust
fn main() -> xcb::Result<()> {
    let (conn, _) = ConnBuilder::new()
        .with_optional_extensions(&[xcb::Extension::Glx])
        .with_auth("MIT-MAGIC-COOKIE-1", "...")
        .to_display("display name")
        .build()?;

     Ok(())
}
```

**Currently**
```rust
fn main() -> xcb::Result<()> {
     let (conn, _) = Connection::connect_to_display_with_auth_info_and_extensions(
         "display_name",
         &[],
         &[Extension::Glx],
         AuthInfo { name: "MIT-MAGIC-COOKIE-1", data: "..." });

    Ok(())
}
```

I've included a basic implementation, just in case you don't like the idea. The `with_extensions(&[xcb::Extension::Glx])`  could be easily replaced by `with_extensions(xcb::Extension::Glx)` for just 1 item with some trait magic, also there are some crates to auto generate this pattern but I'm not very into them, those are also an option.