### PR TITLE
fix #154

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1813,26 +1813,28 @@ impl CodeGen {
                         cg::ind(1),
                         name
                     )?;
-                    writeln!(
-                        out,
-                        "{}assert_eq!(self.format(), P::FORMAT, \"mismatched format of {}::{}::{}\");",
-                        cg::ind(2),
-                        self.xcb_mod,
-                        struct_rs_typ,
-                        name
-                    )?;
                     writeln!(out, "{}unsafe {{", cg::ind(2))?;
-                    writeln!(
-                        out,
-                        "{}let offset = {};",
-                        cg::ind(3),
-                        self.build_rs_expr(wire_off, "self.", "()", fields)
-                    )?;
+                    // #154: format can be zero when len is zero
                     writeln!(
                         out,
                         "{}let len = {};",
                         cg::ind(3),
                         self.build_rs_expr(len_expr, "self.", "()", fields)
+                    )?;
+                    writeln!(out, "{}if len == 0 {{ return &[]; }}", cg::ind(3))?;
+                    writeln!(
+                        out,
+                        "{}assert_eq!(self.format(), P::FORMAT, \"mismatched format of {}::{}::{}\");",
+                        cg::ind(3),
+                        self.xcb_mod,
+                        struct_rs_typ,
+                        name
+                    )?;
+                    writeln!(
+                        out,
+                        "{}let offset = {};",
+                        cg::ind(3),
+                        self.build_rs_expr(wire_off, "self.", "()", fields)
                     )?;
                     writeln!(
                         out,


### PR DESCRIPTION
diff of code generation:
```diff
diff -ur gen/previous/randr.rs gen/current/randr.rs
--- gen/previous/randr.rs	2022-02-13 09:29:55.510376289 +0100
+++ gen/current/randr.rs	2022-02-13 09:30:25.204064677 +0100
@@ -5169,14 +5169,17 @@
     }
 
     pub fn data<P: PropEl>(&self) -> &[P] {
-        assert_eq!(
-            self.format(),
-            P::FORMAT,
-            "mismatched format of randr::GetOutputPropertyReply::data"
-        );
         unsafe {
-            let offset = 32usize;
             let len = ((self.num_items() as usize) * ((self.format() as usize) / 8usize));
+            if len == 0 {
+                return &[];
+            }
+            assert_eq!(
+                self.format(),
+                P::FORMAT,
+                "mismatched format of randr::GetOutputPropertyReply::data"
+            );
+            let offset = 32usize;
             let len = len / std::mem::size_of::<P>();
             let ptr = self.wire_ptr().add(offset) as *const P;
             std::slice::from_raw_parts(ptr, len)
@@ -9739,14 +9742,17 @@
     }
 
     pub fn data<P: PropEl>(&self) -> &[P] {
-        assert_eq!(
-            self.format(),
-            P::FORMAT,
-            "mismatched format of randr::GetProviderPropertyReply::data"
-        );
         unsafe {
-            let offset = 32usize;
             let len = ((self.num_items() as usize) * ((self.format() as usize) / 8usize));
+            if len == 0 {
+                return &[];
+            }
+            assert_eq!(
+                self.format(),
+                P::FORMAT,
+                "mismatched format of randr::GetProviderPropertyReply::data"
+            );
+            let offset = 32usize;
             let len = len / std::mem::size_of::<P>();
             let ptr = self.wire_ptr().add(offset) as *const P;
             std::slice::from_raw_parts(ptr, len)
diff -ur gen/previous/xproto.rs gen/current/xproto.rs
--- gen/previous/xproto.rs	2022-02-13 09:29:58.210406347 +0100
+++ gen/current/xproto.rs	2022-02-13 09:30:27.964100206 +0100
@@ -13744,14 +13744,17 @@
     /// The value of the property. The type is known only at runtime through the [format] field.
     /// It must be casted to the proper type accordingly with the `P` type parameter.
     pub fn value<P: PropEl>(&self) -> &[P] {
-        assert_eq!(
-            self.format(),
-            P::FORMAT,
-            "mismatched format of xproto::GetPropertyReply::value"
-        );
         unsafe {
-            let offset = 32usize;
             let len = ((self.value_len() as usize) * ((self.format() as usize) / 8usize));
+            if len == 0 {
+                return &[];
+            }
+            assert_eq!(
+                self.format(),
+                P::FORMAT,
+                "mismatched format of xproto::GetPropertyReply::value"
+            );
+            let offset = 32usize;
             let len = len / std::mem::size_of::<P>();
             let ptr = self.wire_ptr().add(offset) as *const P;
             std::slice::from_raw_parts(ptr, len)
```