### PR TITLE
Xid types impl Hash

### DIFF
--- a/build/cg/mod.rs
+++ b/build/cg/mod.rs
@@ -489,6 +489,7 @@ impl CodeGen {
         writeln!(out, "use bitflags::bitflags;")?;
         writeln!(out, "use libc::{{self, iovec}};")?;
         writeln!(out, "use std::convert::TryInto;")?;
+        writeln!(out, "use std::hash::{{Hash, Hasher}};")?;
         writeln!(out, "use std::os::unix::prelude::RawFd;")?;
 
         if let Some(ext_info) = self.ext_info.as_ref() {

--- a/build/cg/xid.rs
+++ b/build/cg/xid.rs
@@ -54,7 +54,7 @@ impl CodeGen {
         };
 
         writeln!(out)?;
-        writeln!(out, "#[derive(Copy, Clone, {}PartialEq, Eq)]", dbg)?;
+        writeln!(out, "#[derive(Copy, Clone, {}PartialEq, Eq, Hash)]", dbg)?;
         writeln!(out, "#[repr(C)]")?;
         writeln!(out, "pub struct {} {{", rs_typ)?;
         writeln!(out, "    res_id: u32,")?;
@@ -140,6 +140,12 @@ impl CodeGen {
         writeln!(out, "}}")?;
         writeln!(out)?;
         writeln!(out, "impl Eq for {} {{}}", rs_typ)?;
+        writeln!(out)?;
+        writeln!(out, "impl Hash for {} {{", rs_typ)?;
+        writeln!(out, "    fn hash<H: Hasher>(&self, state: &mut H) {{")?;
+        writeln!(out, "        self.resource_id().hash(state);")?;
+        writeln!(out, "    }}")?;
+        writeln!(out, "}}")?;
 
         for v in variants {
             let variant = if v.variant == "XprotoWindow" {

--- a/src/test.rs
+++ b/src/test.rs
@@ -160,3 +160,24 @@ fn test_cw_is_sorted_distinct() {
         x::Cw::BitGravity(x::Gravity::Center),
     ]));
 }
+
+#[test]
+fn atom_hashmap() {
+    use std::collections::HashMap;
+
+    let map = {
+        let mut map = HashMap::new();
+        map.insert(x::ATOM_ATOM, "Atom");
+        map.insert(x::ATOM_CURSOR, "Cursor");
+        map.insert(x::ATOM_PIXMAP, "Pixmap");
+        map.insert(x::ATOM_STRING, "String");
+        map.insert(x::ATOM_WINDOW, "Window");
+        map
+    };
+
+    assert_eq!(map.get(&x::ATOM_ATOM), Some(&"Atom"));
+    assert_eq!(map.get(&x::ATOM_CURSOR), Some(&"Cursor"));
+    assert_eq!(map.get(&x::ATOM_PIXMAP), Some(&"Pixmap"));
+    assert_eq!(map.get(&x::ATOM_STRING), Some(&"String"));
+    assert_eq!(map.get(&x::ATOM_WINDOW), Some(&"Window"));
+}


### PR DESCRIPTION
Allows to use `Atom` or `Window` as `HashMap` keys.