### PR TITLE
`atoms_struct!` macro

### DIFF
--- a/build/cg/request.rs
+++ b/build/cg/request.rs
@@ -541,6 +541,13 @@ impl CodeGen {
                 info.cookie_rs_typ, info.cookie_rs_typ
             )?;
         }
+        if rs_typ == "InternAtom" {
+            writeln!(out, "///")?;
+            writeln!(
+                out,
+                "/// See also [`xcb::atoms_struct`](crate::atoms_struct)."
+            )?;
+        }
         writeln!(out, "#[derive(Clone, Debug)]")?;
         writeln!(out, "pub struct {}{} {{", rs_typ, generic_decl)?;
         for p in params {

--- a/xml/xproto.xml
+++ b/xml/xproto.xml
@@ -2882,12 +2882,12 @@ The `window` to query.
             <brief>Get atom identifier by name</brief>
             <description>
                 <![CDATA[
-Retrieves the identifier (xcb_atom_t TODO) for the atom with the specified
-name. Atoms are used in protocols like EWMH, for example to store window titles
+Retrieves the identifier for the atom with the specified name.
+Atoms are used in protocols like EWMH, for example to store window titles
 (`_NET_WM_NAME` atom) as property of a window.
 
-If `only_if_exists` is 0, the atom will be created if it does not already exist.
-If `only_if_exists` is 1, `XCB_ATOM_NONE` will be returned if the atom does
+If `only_if_exists` is `false`, the atom will be created if it does not already exist.
+If `only_if_exists` is `true`, [`ATOM_NONE`] will be returned if the atom does
 not yet exist.
       ]]>
             </description>


### PR DESCRIPTION
code is better than speech:
```rust
xcb::atoms_struct!(
    struct Atoms {
        wm_protocols    => b"WM_PROTOCOLS",
        wm_del_window   => b"WM_DELETE_WINDOW",
    }
);

fn main() -> xcb::Result<()> {
    // ...

    let atoms = Atoms::intern_all(&conn)?;

    conn.check_request(conn.send_request_checked(&x::ChangeProperty {
        mode: x::PropMode::Replace,
        window,
        property: atoms.wm_protocols,
        r#type: x::ATOM_ATOM,
        data: &[atoms.wm_del_window],
    }))?;
   
    // ...
}
```
