### PR TITLE
add possible attributes in atoms_struct!

### DIFF
--- a/examples/basic_window.rs
+++ b/examples/basic_window.rs
@@ -1,6 +1,7 @@
 use xcb::{x, Xid};
 
-xcb::atoms_struct!(
+xcb::atoms_struct! {
+    #[derive(Debug)]
     struct Atoms {
         wm_protocols    => b"WM_PROTOCOLS",
         wm_del_window   => b"WM_DELETE_WINDOW",
@@ -8,7 +9,7 @@ xcb::atoms_struct!(
         wm_state_maxv   => b"_NET_WM_STATE_MAXIMIZED_VERT",
         wm_state_maxh   => b"_NET_WM_STATE_MAXIMIZED_HORZ",
     }
-);
+}
 
 fn main() -> xcb::Result<()> {
     let (conn, screen_num) = xcb::Connection::connect(None).unwrap();
@@ -66,6 +67,7 @@ fn main() -> xcb::Result<()> {
 
     // retrieving a few atoms
     let atoms = Atoms::intern_all(&conn)?;
+    println!("atoms = {:#?}", atoms);
 
     // activate the sending of close event through `x::Event::ClientMessage`
     // either the request must be checked as follow, or conn.flush() must be called before entering the loop

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,12 +403,13 @@ mod xproto {
 /// # Example
 /// ```no_run
 /// # use xcb::x;
-/// xcb::atoms_struct!(
+/// xcb::atoms_struct! {
+///     #[derive(Copy, Clone, Debug)]
 ///     struct Atoms {
 ///         wm_protocols    => b"WM_PROTOCOLS",
 ///         wm_del_window   => b"WM_DELETE_WINDOW",
 ///     }
-/// );
+/// }
 ///
 /// fn main() -> xcb::Result<()> {
 /// #   let (conn, screen_num) = xcb::Connection::connect(None)?;
@@ -429,11 +430,15 @@ mod xproto {
 /// ```
 #[macro_export]
 macro_rules! atoms_struct {
-    ( $vis:vis struct $Atoms:ident {
-        $(
-            $field:ident => $name:expr,
-        )*
-    } ) => {
+    (
+        $(#[$outer:meta])*
+        $vis:vis struct $Atoms:ident {
+            $(
+                $field:ident => $name:expr,
+            )*
+        }
+    ) => {
+        $(#[$outer])*
         $vis struct $Atoms {
             $($field: xcb::x::Atom,)*
         }
@@ -453,7 +458,7 @@ macro_rules! atoms_struct {
                 })
             }
         }
-    }
+    };
 }
 
 pub mod bigreq {


### PR DESCRIPTION
code is better than speech:
```rust
xcb::atoms_struct!(
    #[derive(Debug, Copy, Clone)]
    struct Atoms {
        wm_protocols    => b"WM_PROTOCOLS",
        wm_del_window   => b"WM_DELETE_WINDOW",
    }
);

fn main() -> xcb::Result<()> {
    // ...

    let atoms = Atoms::intern_all(&conn)?;

    conn.check_request(conn.send_request_checked(&x::ChangeProperty {
        mode: x::PropMode::Replace,
        window,
        property: atoms.wm_protocols,
        r#type: x::ATOM_ATOM,
        data: &[atoms.wm_del_window],
    }))?;
   
    // ...
}
```
