### PR TITLE
Add a screenshot example utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ xvmc = [ "xv" ]
 
 [dev-dependencies]
 gl = "0.14.0"
+png = "0.17.5"
 
 [dev-dependencies.x11]
 version = "2.19.1"
@@ -119,6 +120,9 @@ name = "screen_info"
 [[example]]
 name = "xinput_stylus_events"
 required-features = ["xinput"]
+
+[[example]]
+name = "screenshot"
 
 [[example]]
 name = "xkb_init"

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,0 +1,47 @@
+extern crate xcb;
+
+use std::{fs::File, io::BufWriter};
+use xcb::x;
+
+fn main() {
+    let (conn, screen_num) = xcb::Connection::connect(None).unwrap();
+    let setup = conn.get_setup();
+    let screen = setup.roots().nth(screen_num as usize).unwrap();
+
+    let width = screen.width_in_pixels();
+    let height = screen.height_in_pixels();
+
+    let cookie = conn.send_request(&x::GetImage {
+        format: x::ImageFormat::ZPixmap,
+        drawable: x::Drawable::Window(screen.root()),
+        x: 0,
+        y: 0,
+        width,
+        height,
+        plane_mask: u32::MAX,
+    });
+
+    let file = File::create("screenshot.png").unwrap();
+    let writer = BufWriter::new(file);
+    let mut encoder = png::Encoder::new(writer, width as _, height as _);
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .expect("Failed to write image header");
+
+    let reply = conn.wait_for_reply(cookie).unwrap();
+
+    let src = reply.data();
+    let mut data = vec![0; width as usize * height as usize * 3];
+    for (src, dest) in src.chunks(4).zip(data.chunks_mut(3)) {
+        // Captured image stores orders pixels as BGR, so we need to
+        // reorder them.
+        dest[0] = src[2];
+        dest[1] = src[1];
+        dest[2] = src[0];
+    }
+    writer
+        .write_image_data(&data)
+        .expect("Failed to write image data");
+}


### PR DESCRIPTION
Example utility that takes a screenshot with `xcb_get_image` and writes it to disk as a png.