### PR TITLE
Add Event::as_raw(), Connection::resolve_event()

### DIFF
--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -358,7 +358,11 @@ impl CodeGen {
                 // We can't emit the different type, but it is "OK" to cast
                 // it as xcb_generic_event_t as the response_type can be
                 // used to distinguish the correct type
-                writeln!(out, "      Self::{}(e) => e.as_raw() as *mut xcb_generic_event_t,", event.variant)?;
+                writeln!(
+                    out,
+                    "      Self::{}(e) => e.as_raw() as *mut xcb_generic_event_t,",
+                    event.variant
+                )?;
             } else {
                 writeln!(out, "      Self::{}(e) => e.as_raw(),", event.variant)?;
             }

--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -345,6 +345,28 @@ impl CodeGen {
         }
         writeln!(out, "}}")?;
 
+        writeln!(out)?;
+        writeln!(out, "impl Event {{")?;
+        writeln!(out, "  pub fn as_raw(&self) -> *mut xcb_generic_event_t {{")?;
+        writeln!(out, "    match self {{")?;
+        for event in &self.events {
+            if event.is_xge && self.xcb_mod == "xproto" {
+                // same comment as above
+                continue;
+            }
+            if event.is_xge {
+                // We can't emit the different type, but it is "OK" to cast
+                // it as xcb_generic_event_t as the response_type can be
+                // used to distinguish the correct type
+                writeln!(out, "      Self::{}(e) => e.as_raw() as *mut xcb_generic_event_t,", event.variant)?;
+            } else {
+                writeln!(out, "      Self::{}(e) => e.as_raw(),", event.variant)?;
+            }
+        }
+        writeln!(out, "    }}")?;
+        writeln!(out, "  }}")?;
+        writeln!(out, "}}")?;
+
         let has_xge = self.events.iter().any(|ev| ev.is_xge);
         let has_non_xge = !self.events.iter().all(|ev| ev.is_xge);
         let _last_event = self.events.iter().map(|ev| ev.number).max().unwrap();

--- a/src/base.rs
+++ b/src/base.rs
@@ -1158,7 +1158,8 @@ impl Connection {
     }
 
     /// Resolve an xcb_generic_event_t pointer into an Event.
-    /// The pointer must not be NULL.
+    /// # Safety
+    /// The caller is repsonsible to ensure that the `ev` pointer is not NULL.
     /// The ownership of the pointer is effectively transferred to the
     /// returned Event and it will be destroyed when the Event is
     /// dropped.

--- a/src/base.rs
+++ b/src/base.rs
@@ -1157,6 +1157,15 @@ impl Connection {
         }
     }
 
+    /// Resolve an xcb_generic_event_t pointer into an Event.
+    /// The pointer must not be NULL.
+    /// The ownership of the pointer is effectively transferred to the
+    /// returned Event and it will be destroyed when the Event is
+    /// dropped.
+    pub unsafe fn resolve_event(&self, ev: &mut xcb_generic_event_t) -> Event {
+        event::resolve_event(ev, &self.ext_data)
+    }
+
     unsafe fn handle_poll_for_event(&self, ev: *mut xcb_generic_event_t) -> Result<Option<Event>> {
         if ev.is_null() {
             self.has_error()?;

--- a/src/event.rs
+++ b/src/event.rs
@@ -111,6 +111,43 @@ pub enum Event {
     Unknown(UnknownEvent),
 }
 
+impl Event {
+    pub fn as_raw(&self) -> *mut xcb_generic_event_t {
+        match self {
+            Self::X(e) => e.as_raw(),
+            #[cfg(feature = "damage")]
+            Self::Damage(e) => e.as_raw(),
+            #[cfg(feature = "dri2")]
+            Self::Dri2(e) => e.as_raw(),
+            #[cfg(feature = "glx")]
+            Self::Glx(e) => e.as_raw(),
+            #[cfg(feature = "present")]
+            Self::Present(e) => e.as_raw(),
+            #[cfg(feature = "randr")]
+            Self::RandR(e) => e.as_raw(),
+            #[cfg(feature = "screensaver")]
+            Self::ScreenSaver(e) =>e.as_raw(),
+            #[cfg(feature = "shape")]
+            Self::Shape(e) => e.as_raw(),
+            #[cfg(feature = "shm")]
+            Self::Shm(e) => e.as_raw(),
+            #[cfg(feature = "sync")]
+            Self::Sync(e) => e.as_raw(),
+            #[cfg(feature = "xfixes")]
+            Self::XFixes(e) => e.as_raw(),
+            #[cfg(feature = "xinput")]
+            Self::Input(e) => e.as_raw(),
+            #[cfg(feature = "xkb")]
+            Self::Xkb(e) => e.as_raw(),
+            #[cfg(feature = "xprint")]
+            Self::XPrint(e) => e.as_raw(),
+            #[cfg(feature = "xv")]
+            Self::Xv(e) => e.as_raw(),
+            Self::Unknown(e) => e.as_raw(),
+        }
+    }
+}
+
 /// an event was not recognized as part of the core protocol or any enabled extension
 pub struct UnknownEvent {
     raw: *mut xcb_generic_event_t,

--- a/src/event.rs
+++ b/src/event.rs
@@ -126,7 +126,7 @@ impl Event {
             #[cfg(feature = "randr")]
             Self::RandR(e) => e.as_raw(),
             #[cfg(feature = "screensaver")]
-            Self::ScreenSaver(e) =>e.as_raw(),
+            Self::ScreenSaver(e) => e.as_raw(),
             #[cfg(feature = "shape")]
             Self::Shape(e) => e.as_raw(),
             #[cfg(feature = "shm")]


### PR DESCRIPTION
In some ffi scenarios it is necessary to extract the underlying
event pointer.  The `Event::as_raw` method serves this purpose.

I couldn't implement the `Raw<>` trait for `Event` because the
`from_raw` method requires additional context in order to perform
the inverse of the `as_raw` method, so `Event::as_raw` is just
a standalone method.

I added `Connection::resolve_event` as the inverse operation
to give some symmetry.

closes: https://github.com/rust-x-bindings/rust-xcb/issues/188