### PR TITLE
avoid segfault if eg: DISPLAY is unset when using xlib

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -535,6 +535,9 @@ pub enum ConnError {
     ClosedInvalidScreen,
     /// Connection closed because some file descriptor passing operation failed.
     ClosedFdPassingFailed,
+    /// XOpenDisplay returned NULL
+    #[cfg(feature = "xlib_xcb")]
+    XOpenDisplay,
 }
 
 impl ConnError {
@@ -552,6 +555,10 @@ impl ConnError {
             }
             ConnError::ClosedFdPassingFailed => {
                 "Connection closed, some file descriptor passing operation failed"
+            }
+            #[cfg(feature = "xlib_xcb")]
+            ConnError::XOpenDisplay => {
+                "XOpenDisplay failed to open a display. Check the $DISPLAY env var"
             }
         }
     }
@@ -722,6 +729,9 @@ impl Connection {
     pub fn connect_with_xlib_display() -> ConnResult<(Connection, i32)> {
         unsafe {
             let dpy = xlib::XOpenDisplay(ptr::null());
+            if dpy.is_null() {
+                return Err(ConnError::XOpenDisplay);
+            }
 
             check_connection_error(XGetXCBConnection(dpy))?;
 
@@ -752,6 +762,9 @@ impl Connection {
     ) -> ConnResult<(Connection, i32)> {
         unsafe {
             let dpy = xlib::XOpenDisplay(ptr::null());
+            if dpy.is_null() {
+                return Err(ConnError::XOpenDisplay);
+            }
 
             check_connection_error(XGetXCBConnection(dpy))?;
 


### PR DESCRIPTION
Avoid this segfault:

```
>>> bt
 #0  XGetXCBConnection (dpy=0x0) at /usr/src/debug/libX11-1.7.3.1-2.fc36.x86_64/src/x11_xcb.c:9
 #1  0x0000555556eee5c7 in xcb::base::Connection::connect_with_xlib_display_and_extensions (mandatory=..., optional=...) at /home/wez/.cargo/git/checkouts/rust-xcb-4cfa40fd56e21cc5/362404a/src/base.rs:756
 #2  0x0000555556bee1ae in window::os::x11::connection::XConnection::create_new () at window/src/os/x11/connection.rs:324
 #3  0x0000555556ba7480 in window::os::x_and_wayland::Connection::create_new () at window/src/os/x_and_wayland.rs:49
 #4  0x0000555555a437e2 in window::connection::ConnectionOps::init<window::os::x_and_wayland::Connection> () at /home/wez/wez-personal/wezterm/window/src/connection.rs:30
 #5  0x0000555555a6264c in wezterm_gui::frontend::GuiFrontEnd::try_new () at wezterm-gui/src/frontend.rs:32
 #6  0x0000555555a64789 in wezterm_gui::frontend::try_new () at wezterm-gui/src/frontend.rs:318
 #7  0x0000555555bd2d2d in wezterm_gui::run_terminal_gui (opts=...) at wezterm-gui/src/main.rs:620
 #8  0x0000555555bd877c in wezterm_gui::run () at wezterm-gui/src/main.rs:968
 #9  0x0000555555bd33d1 in wezterm_gui::main () at wezterm-gui/src/main.rs:667
```