### PR TITLE
Fix panic when present feature is enabled

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -207,7 +207,7 @@ pub(crate) unsafe fn resolve_event(
     }
 
     for data in extension_data {
-        if response_type >= data.first_event {
+        if response_type >= data.first_event && data.first_event != 0 {
             match data.ext {
                 #[cfg(feature = "damage")]
                 Extension::Damage => {


### PR DESCRIPTION
I think the panic is because there are no non-generic events in the definition for this extension.

Skipping the attempt to resolve avoids the panic, but I do wonder whether the underlying generated resolve_wire_event methods should just return None for this case.

refs: #195