### PR TITLE
Expose "format" property getter

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1669,8 +1669,11 @@ impl CodeGen {
                     //       it's not necessary to make them public as we expose lists as Rust
                     //       slices. However, when those fields are named width or height, they're
                     //       not simply the length of a slice, and they must be exposed so that the
-                    //       user can treat the slice as an image.
-                    let visibility = if *is_fieldref && !(name == "width" || name == "height") {
+                    //       user can treat the slice as an image. The format field is important for
+                    //       GetPropertyReply where the value getter would panic if formats mismatch.
+                    let visibility = if *is_fieldref
+                        && !(name == "width" || name == "height" || name == "format")
+                    {
                         ""
                     } else {
                         "pub "

--- a/gen/diff.sh
+++ b/gen/diff.sh
@@ -2,7 +2,7 @@
 
 if [ -z "$1" ]
 then
-    echo -e "Error: a module name ust be supplied as argument"
+    echo -e "Error: a module name must be supplied as argument"
     exit 1
 fi
 


### PR DESCRIPTION
There's a preexisting whitelist of properties/fields that should not be
hidden just because they appear as a part of another expression (most
notably, lists) as a `<fieldref>` expression.

For the client code it's important to check the format, otherwise the
code might panic due to the assert inside `.data::<PropEl>()` accessor.

Fixes #209