### PR TITLE
Implement AsRawXcbConnection for Connection

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,38 +24,3 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install \
-            libgl1-mesa-dev \
-            libxcb-composite0-dev \
-            libxcb-damage0-dev \
-            libxcb-dpms0-dev \
-            libxcb-dri2-0-dev \
-            libxcb-dri3-dev \
-            libxcb-glx0-dev \
-            libxcb-present-dev \
-            libxcb-randr0-dev \
-            libxcb-record0-dev \
-            libxcb-render0-dev \
-            libxcb-res0-dev \
-            libxcb-screensaver0-dev \
-            libxcb-shape0-dev \
-            libxcb-shm0-dev \
-            libxcb-sync-dev \
-            libxcb-xf86dri0-dev \
-            libxcb-xfixes0-dev \
-            libxcb-xinerama0-dev \
-            libxcb-xkb-dev \
-            libxcb-xtest0-dev \
-            libxcb-xv0-dev \
-            libxcb-xvmc0-dev \
-            libx11-xcb-dev
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ quick-xml = "0.22.0"
 [dependencies]
 libc = "0.2.102"
 bitflags = "1.3.2"
+as-raw-xcb-connection = { version = "1.0", optional = true }
 
 [dependencies.x11]
 version = "2.19.0"

--- a/src/base.rs
+++ b/src/base.rs
@@ -1636,6 +1636,13 @@ impl AsRawFd for Connection {
     }
 }
 
+// SAFETY: We provide a valid xcb_connection_t that is valid for as long as required by the trait.
+unsafe impl as_raw_xcb_connection::AsRawXcbConnection for Connection {
+    fn as_raw_xcb_connection(&self) -> *mut as_raw_xcb_connection::xcb_connection_t {
+        self.get_raw_conn().cast()
+    }
+}
+
 impl Drop for Connection {
     fn drop(&mut self) {
         #[cfg(feature = "debug_atom_names")]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1637,6 +1637,7 @@ impl AsRawFd for Connection {
 }
 
 // SAFETY: We provide a valid xcb_connection_t that is valid for as long as required by the trait.
+#[cfg(feature = "as-raw-xcb-connection")]
 unsafe impl as_raw_xcb_connection::AsRawXcbConnection for Connection {
     fn as_raw_xcb_connection(&self) -> *mut as_raw_xcb_connection::xcb_connection_t {
         self.get_raw_conn().cast()


### PR DESCRIPTION
There is a new crate as-raw-xcb-connection providing a trait for getting a raw pointer for a libxcb xcb_connection_t. Implement this trait for Connection.

Closes: https://github.com/rust-x-bindings/rust-xcb/issues/217
Signed-off-by: Uli Schlachter <psychon@znc.in>

---

This is a draft since I want to wait for version 1.0 of AsRawXcbConnection before merging. See https://github.com/psychon/as-raw-xcb-connection/issues/1