### PR TITLE
Clarify phrasing of xkb example error message

### DIFF
--- a/examples/xkb_init.rs
+++ b/examples/xkb_init.rs
@@ -11,7 +11,7 @@ fn main() -> xcb::Result<()> {
             wanted_minor: 0,
         }))?;
 
-        assert!(xkb_ver.supported(), "xkb-1.0 is not supported");
+        assert!(xkb_ver.supported(), "xkb-1.0 support is required");
     }
 
     // we now select what events we want to receive


### PR DESCRIPTION
The existing assert phrasing gives the impression that this library does not support xkb-1.0, while the code around it actually verifies that this version is in use. This PR adjusts the phrasing of the message to make the meaning somewhat more easy to understand.