### PR TITLE
prepare 1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2023-04-08 - various authors
+### Fixed
+ - updated `quick-xml` as the old one will no longer be compatible with future rust versions
+
+### Changed
+ - Implement `AsRawXcbConnection` for `Connection`
+
 ## [1.2.0] - 2022-11-03 - various authors
 ### Fixed
  - Segfault when DISPLAY is unset when using xlib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcb"
-version = "1.2.0"
+version = "1.2.1"
 authors = [ "Remi Thebault <remi.thebault@gmail.com>" ]
 description = "Rust safe bindings for XCB"
 repository = "https://github.com/rust-x-bindings/rust-xcb"


### PR DESCRIPTION
Hi @rtbo would you please be so kind and create a new release for the quick-xml fix?
I was not sure weather this is a 1.2.1 or 1.3.0 release because the `Error` enum in the build folder changes its public interface, but i though as this is only used for building and not an exported Error of this crate, it probably still fits in 1.2.1.

In case you have further requests or questions, or want me to change it to 1.3.0, just answer me :)