### PR TITLE
fix alignment for SendEventDest

### DIFF
--- a/build/cg/enum.rs
+++ b/build/cg/enum.rs
@@ -206,14 +206,8 @@ impl CodeGen {
             out,
             "    pub fn serialize(&self, wire_buf: &mut [u8]) -> usize {{"
         )?;
-        writeln!(out, "        debug_assert!(wire_buf.len() >= 4);")?;
-        writeln!(out, "        unsafe {{")?;
-        writeln!(
-            out,
-            "            *(wire_buf.as_mut_ptr() as *mut u32) = self.resource_id();"
-        )?;
-        writeln!(out, "        }}")?;
-        writeln!(out, "        4")?;
+        writeln!(out, "        let id = self.resource_id();")?;
+        writeln!(out, "        WiredOut::serialize(&id, wire_buf)")?;
         writeln!(out, "    }}")?;
         writeln!(out, "}}")?;
 


### PR DESCRIPTION
Use the implementation from https://github.com/rust-x-bindings/rust-xcb/pull/225 for this, rather than reimplementing the serialization logic inline.

refs: https://github.com/rust-x-bindings/rust-xcb/issues/229
refs: https://github.com/wez/wezterm/issues/3838