### PR TITLE
dereferencing through `copy_nonoverlapping`

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1622,7 +1622,10 @@ impl CodeGen {
                         "            let ptr = self.wire_ptr().add(offset) as *const {};",
                         q_rs_typ
                     )?;
-                    writeln!(out, "            let val = *ptr as u32;")?;
+                    writeln!(
+                        out,
+                        "            let val = base::value_from_ptr(ptr) as u32;"
+                    )?;
                     writeln!(
                         out,
                         "            std::mem::transmute::<u32, {}>(val)",
@@ -1707,22 +1710,11 @@ impl CodeGen {
                     )?;
                     writeln!(
                         out,
-                        "{}let src = self.wire_ptr().add(offset) as *const {};",
+                        "{}let ptr = self.wire_ptr().add(offset) as *const {};",
                         cg::ind(3),
                         q_rs_typ
                     )?;
-                    writeln!(
-                        out,
-                        "{}let mut val = std::mem::MaybeUninit::<{}>::uninit();",
-                        cg::ind(3),
-                        q_rs_typ
-                    )?;
-                    writeln!(
-                        out,
-                        "{}std::ptr::copy_nonoverlapping(src, val.as_mut_ptr(), 1);",
-                        cg::ind(3)
-                    )?;
-                    writeln!(out, "            val.assume_init()")?;
+                    writeln!(out, "{}base::value_from_ptr(ptr)", cg::ind(3),)?;
                     writeln!(out, "        }}")?;
                     writeln!(out, "    }}")?;
                 }

--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1707,11 +1707,22 @@ impl CodeGen {
                     )?;
                     writeln!(
                         out,
-                        "{}let ptr = self.wire_ptr().add(offset) as *const {};",
+                        "{}let src = self.wire_ptr().add(offset) as *const {};",
                         cg::ind(3),
                         q_rs_typ
                     )?;
-                    writeln!(out, "            *ptr")?;
+                    writeln!(
+                        out,
+                        "{}let mut val = std::mem::MaybeUninit::<{}>::uninit();",
+                        cg::ind(3),
+                        q_rs_typ
+                    )?;
+                    writeln!(
+                        out,
+                        "{}std::ptr::copy_nonoverlapping(src, val.as_mut_ptr(), 1);",
+                        cg::ind(3)
+                    )?;
+                    writeln!(out, "            val.assume_init()")?;
                     writeln!(out, "        }}")?;
                     writeln!(out, "    }}")?;
                 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -1750,6 +1750,17 @@ pub(crate) fn align_pad(base: usize, align: usize) -> usize {
     (-base & (align - 1)) as usize
 }
 
+/// Get a value from a pointer, using ptr::copy_nonoverlapping to avoid alignment issues
+///
+/// # Safety
+/// The pointer must point to a valid `T` value
+#[inline]
+pub(crate) unsafe fn value_from_ptr<T>(ptr: *const T) -> T {
+    let mut val = mem::MaybeUninit::<T>::uninit();
+    ptr::copy_nonoverlapping(ptr, val.as_mut_ptr(), 1);
+    val.assume_init()
+}
+
 #[test]
 fn test_align_pad() {
     // align 1


### PR DESCRIPTION
this is what is done internally as well by `copy_from_slice`, so it should deal correctly with alignment

fixes #246