### PR TITLE
Add support for libxcb API before version 1.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,10 @@ optional = true
 features = ["xlib"]
 
 [features]
+default = ["libxcb_v1_14"]
 debug_atom_names = []
 xlib_xcb = ["x11/xlib"]
+libxcb_v1_14 = []
 
 composite = [ "xfixes" ]
 damage = [ "xfixes" ]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1754,6 +1754,9 @@ impl Connection {
     ///
     /// This retrieves the total number of bytes read from this connection,
     /// to be used for diagnostic/monitoring/informative purposes.
+    ///
+    /// Since: libxcb 1.14
+    #[cfg(feature = "libxcb_v1_14")]
     pub fn total_read(&self) -> usize {
         unsafe { xcb_total_read(self.c) as usize }
     }
@@ -1764,6 +1767,9 @@ impl Connection {
     ///
     /// This retrieves the total number of bytes written to this connection,
     /// to be used for diagnostic/monitoring/informative purposes.
+    ///
+    /// Since: libxcb 1.14
+    #[cfg(feature = "libxcb_v1_14")]
     pub fn total_written(&self) -> usize {
         unsafe { xcb_total_written(self.c) as usize }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,11 @@
 //! have side effects (`x::GetAtomName` requests) which can sometimes not be desirable.
 //! The feature should therefore only be activated when needed.
 //!
+//! ## `libxcb_v1_14`
+//!
+//! This feature is enabled by default and activates the libxcb API version 1.14.
+//! To use a version of the libxcb API prior to 1.14, you must disable it.
+//!
 //! ## Extension features
 //!
 //! The following X extensions are activated by a cargo feature:


### PR DESCRIPTION
Version 1.14 of libxcb introduced the functions xcb_total_read() and xcb_total_written(). This PR adds a feature (enabled by default) to activate these functions. Disabling the feature allows xcb-rs to support libxcb API versions before 1.14.