### PR TITLE
Remove assert for XCB_GE_GENERIC

### DIFF
--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -630,11 +630,6 @@ impl CodeGen {
             "{}debug_assert!(response_type != 0, \"This is not an event but an error!\");",
             cg::ind(2),
         )?;
-        writeln!(
-            out,
-            "{}debug_assert!(response_type != XCB_GE_GENERIC, \"This is a GE_GENERIC event!\");",
-            cg::ind(2),
-        )?;
         if self.xcb_mod == "xkb" {
             writeln!(
                 out,


### PR DESCRIPTION
Closes #257 

This looks like a logical mistake in the code.  The events logic is the following:
```rust
pub(crate) unsafe fn resolve_event(
    event: *mut xcb_generic_event_t,
    extension_data: &[ExtensionData],
) -> Event {
    let response_type = (*event).response_type & 0x7F;

    if response_type == XCB_GE_GENERIC {
        //  Special handler for GE_GENERIC
    }

    for data in extension_data {
        if response_type >= data.first_event && data.first_event != 0 {
            // Handle extensions here
        }
    }

    x::Event::resolve_wire_event(0, event) // CRASH HERE
```

We can either refactor `resolve_event` to avoid going into `resolve_wire_event` if the first check passes. Or we can simply remove the debug assert. The `resolve_wire_event` will gracefully return `None` in this case.resolve_wire_event