### PR TITLE
make `resolve_error` public API

### DIFF
--- a/build/cg/event.rs
+++ b/build/cg/event.rs
@@ -654,14 +654,14 @@ impl CodeGen {
 
             writeln!(
                 out,
-                "{}{} => Some(Event::{}({}::from_raw(raw))),",
+                "{}{} => std::option::Option::Some(Event::{}({}::from_raw(raw))),",
                 cg::ind(3),
                 event.number,
                 event.variant,
                 event.rs_typ
             )?;
         }
-        writeln!(out, "{}_ => None,", cg::ind(3))?;
+        writeln!(out, "{}_ => std::option::Option::None,", cg::ind(3))?;
         writeln!(out, "{}}}", cg::ind(2))?;
         writeln!(out, "{}}}", cg::ind(1))?;
         writeln!(out, "}}")?;

--- a/src/event.rs
+++ b/src/event.rs
@@ -195,7 +195,19 @@ impl Drop for UnknownEvent {
     }
 }
 
-pub(crate) unsafe fn resolve_event(
+/// Resolve an event from the X server
+///
+/// If the event originates from an extension, the `extension_data` parameter must contain the
+/// data for the extension of origin.
+/// If the resolution fails, an `Event::Unknown` is returned.
+///
+/// # Panics
+/// The function will panic if the matches with an `XCB_GE_GENERIC` event, but can't
+/// be resolved as such.
+///
+/// # Safety
+/// The caller must ensure that `event` is a valid pointer to an `xcb_generic_event_t`.
+pub unsafe fn resolve_event(
     event: *mut xcb_generic_event_t,
     extension_data: &[ExtensionData],
 ) -> Event {

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -269,7 +269,13 @@ pub struct ExtensionData {
     pub first_error: u8,
 }
 
-pub(crate) fn cache_extensions_data(
+/// Returns the extension data for the given extensions.
+/// This function may block as the data will be queried from the server
+/// if not already cached.
+///
+/// #Panics
+/// This function will panic if a mandatory extension is not present on the server.
+pub fn cache_extensions_data(
     conn: *mut xcb_connection_t,
     mandatory: &[Extension],
     optional: &[Extension],


### PR DESCRIPTION
- `UnknownError` introduced and returned if resolution fails instead of panicking
 - Better consistency between error and event API
 - `Connection::resolve_error` is introduced
 - `cache_extensions_data` is public

See https://github.com/rust-x-bindings/rust-xcb/issues/265