### PR TITLE
Expose "keycodes_per_modifier" property getter

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1683,8 +1683,13 @@ impl CodeGen {
                     //       not simply the length of a slice, and they must be exposed so that the
                     //       user can treat the slice as an image. The format field is important for
                     //       GetPropertyReply where the value getter would panic if formats mismatch.
+                    //       The keycodes_per_modifier field is needed for iterating the list of
+                    //       keycodes returned in GetModifierMappingReply.
                     let visibility = if *is_fieldref
-                        && !(name == "width" || name == "height" || name == "format")
+                        && !(name == "width"
+                            || name == "height"
+                            || name == "format"
+                            || name == "keycodes_per_modifier")
                     {
                         ""
                     } else {


### PR DESCRIPTION
The [`GetModifierMapping`](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#requests:GetModifierMapping) request returns a list of keycodes. Client code needs to iterate this list in chunks of keycodes_per_modifier to visit all keycodes for each of the 8 modifiers (Shift, Lock, Control, Mod1, Mod2, Mod3, Mod4, Mod5).

The preexisting whitelist of properties/fields that should not be hidden has been extended to include this field.

Fixes #271

The generated code diff looks like this:
```diff
diff main/xinput.rs fix/xinput.rs
21933c21933
<     fn keycodes_per_modifier(&self) -> u8 {
---
>     pub fn keycodes_per_modifier(&self) -> u8 {
diff main/xproto.rs fix/xproto.rs
26678c26678
<     fn keycodes_per_modifier(&self) -> u8 {
---
>     pub fn keycodes_per_modifier(&self) -> u8 {
```