### PR TITLE
Fix improper unaligned reads in `value_from_ptr`

### DIFF
--- a/build/cg/struct.rs
+++ b/build/cg/struct.rs
@@ -1618,10 +1618,7 @@ impl CodeGen {
                         "            let ptr = self.wire_ptr().add(offset) as *const {};",
                         q_rs_typ
                     )?;
-                    writeln!(
-                        out,
-                        "            let val = base::value_from_ptr(ptr) as u32;"
-                    )?;
+                    writeln!(out, "            let val = ptr.read_unaligned() as u32;")?;
                     writeln!(
                         out,
                         "            std::mem::transmute::<u32, {}>(val)",
@@ -1715,7 +1712,7 @@ impl CodeGen {
                         cg::ind(3),
                         q_rs_typ
                     )?;
-                    writeln!(out, "{}base::value_from_ptr(ptr)", cg::ind(3),)?;
+                    writeln!(out, "{}ptr.read_unaligned()", cg::ind(3),)?;
                     writeln!(out, "        }}")?;
                     writeln!(out, "    }}")?;
                 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -2078,17 +2078,6 @@ pub(crate) fn align_pad(base: usize, align: usize) -> usize {
     (-base & (align - 1)) as usize
 }
 
-/// Get a value from a pointer, using ptr::copy_nonoverlapping to avoid alignment issues
-///
-/// # Safety
-/// The pointer must point to a valid `T` value
-#[inline]
-pub(crate) unsafe fn value_from_ptr<T>(ptr: *const T) -> T {
-    let mut val = mem::MaybeUninit::<T>::uninit();
-    ptr::copy_nonoverlapping(ptr, val.as_mut_ptr(), 1);
-    val.assume_init()
-}
-
 #[test]
 fn test_align_pad() {
     // align 1


### PR DESCRIPTION
[copy_nonoverlapping](https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html) documents that its pointer must be aligned for a valid read, otherwise the call will be UB.

This patch will fix that, and I *believe* it will fix #269. (I tried @igor-petruk's oatbar at commit https://github.com/igor-petruk/oatbar/commit/baf16278217012d9bec6c54e201d47379a263458 which is what he linked in the issue, changed the Cargo.toml to depend on my local copy that had this change and did `cargo run`, and I didn't get a crash.)

This was only somewhat recently noticed because Rust started checking these preconditions in [Rust 1.78](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#asserting-unsafe-preconditions).

As some notes:

* should we add ` debug_assert!(!ptr.is_null())` to this function?
* is there a point in having this function now vs modifying the code generator to call `read_unaligned`?