### PR TITLE
Export well-known RandR property names (for real)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] -  - various authors
+### Added
+ - export well-known RandR output property names, this time for real
 
 ## [1.5.0] - 2024-11-09 - various authors
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,7 +630,7 @@ pub mod randr {
     /// For information on what the various properties mean, see the [RandR specification][randr-spec]
     ///
     /// [randr-spec]: https://cgit.freedesktop.org/xorg/proto/randrproto/tree/randrproto.txt#n1860
-    mod property {
+    pub mod property {
         #[doc(alias = "RR_PROPERTY_BACKLIGHT")]
         pub const BACKLIGHT: &str = "Backlight";
 


### PR DESCRIPTION
This was first done in #240, but a missing `pub` made it inaccessible.

The changelog for the original change was (accidentally) removed in #249 before appearing in a release, so we can now announce it with full parade :confetti_ball: