### PR TITLE
fix unsound API `xcb::Connection::connect_to_fd*`

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -883,7 +883,6 @@ impl Connection {
         conn.has_error().map(|_| conn)
     }
 
-
     /// Connects to the X server with an open socket file descriptor and optional authentification info.
     ///
     /// Connects to an X server, given the open socket fd and the


### PR DESCRIPTION
A double drop of FD is possible in safe code because xcb takes ownership of the FD, and `xcb::Connection::connect_to_fd` doesn't enforce that. 
This fix changes the `connect_to_fd` argument from `RawFd` to `OwnedFd` to enforce the user to release ownership of the FD.
To prevent semver clash,  current functions are going to deprecation and  new ones are created.
fix #167 
fix #282