### PR TITLE
Implement PropEl for Pixmap type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,11 @@ mod xproto {
         const FORMAT: u8 = 32;
     }
 
+    impl PropEl for Pixmap {
+        // _XROOTPMAP_ID and ESETROOT_PMAP_ID return a pixmap
+        const FORMAT: u8 = 32;
+    }
+
     include!(concat!(env!("OUT_DIR"), "/xproto.rs"));
 }
 


### PR DESCRIPTION
`_XROOTPMAP_ID` and `ESETROOT_PMAP_ID` properties set on the root account when updating the background store the ID of the pixmap with the background image.