### PR TITLE
Update dependencies and modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,14 +10,12 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          channel: stable
 
       - name: Install dependencies
         run: |
@@ -27,25 +25,13 @@ jobs:
             libx11-xcb-dev
 
       - name: Run cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-features
+        run: cargo build --all-features
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features all-extensions,xlib_xcb
+        run: cargo test --features all-extensions,xlib_xcb
 
       - name: Run cargo test (dl)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features all-extensions,xlib_xcb_dl
+        run: cargo test --features all-extensions,xlib_xcb_dl
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all-features
+        run: cargo doc --all-features

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,17 +10,13 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          channel: stable
+          components: rustfmt
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ edition = "2018"
 all-features = true
 
 [build-dependencies]
-quick-xml = "0.30.0"
+quick-xml = "0.41"
 
 [dependencies]
-libc = "0.2.102"
-bitflags = "1.3.2"
+libc = "0.2"
+bitflags = "2.13"
 as-raw-xcb-connection = { version = "1.0", optional = true }
 libloading = { version = "0.9.0", optional = true }
 
 [dependencies.x11]
-version = "2.19.0"
+version = "2.21"
 optional = true
 features = ["xlib"]
 
 [dependencies.x11-dl]
-version = "2.19.0"
+version = "2.21"
 optional = true
 
 [features]
@@ -111,11 +111,11 @@ xvmc = ["xv"]
 
 [dev-dependencies]
 gl = "0.14.0"
-png = "0.17.5"
-tiny-xlib = "0.2.4"
+png = "0.18"
+tiny-xlib = "0.2"
 
 [dev-dependencies.x11]
-version = "2.19.1"
+version = "2.21"
 features = ["xlib", "glx"]
 
 [[example]]

--- a/build/cg/enum.rs
+++ b/build/cg/enum.rs
@@ -226,6 +226,10 @@ impl CodeGen {
         if let Some(doc) = doc {
             doc.emit(out, 1)?;
         }
+        writeln!(
+            out,
+            "    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]"
+        )?;
         writeln!(out, "    pub struct {}: u32 {{", rs_typ)?;
         for item in items {
             if let Some(text) = &item.2 {

--- a/build/parse.rs
+++ b/build/parse.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::attributes::{Attribute, Attributes};
-use quick_xml::events::{BytesStart, Event as XmlEv};
+use quick_xml::events::{BytesStart, BytesText, Event as XmlEv};
 use quick_xml::Reader as XmlReader;
+use quick_xml::{escape, XmlVersion};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
@@ -43,7 +44,9 @@ impl From<quick_xml::Error> for Error {
     fn from(err: quick_xml::Error) -> Self {
         match err {
             quick_xml::Error::Io(e) => Error::IO(e),
-            quick_xml::Error::NonDecodable(Some(e)) => Error::Utf8(e),
+            quick_xml::Error::Encoding(quick_xml::encoding::EncodingError::Utf8(e)) => {
+                Error::Utf8(e)
+            }
             e => Error::Xml(e),
         }
     }
@@ -196,7 +199,7 @@ impl<B: BufRead> Iterator for &mut Parser<B> {
                             })
                         }
                         (None, None, None, None) => None,
-                        _ => panic!("incomplete extension info for {}", &mod_name),
+                        _ => panic!("incomplete extension info for {}", mod_name),
                     };
 
                     Some(Ok(Event::ModuleInfo {
@@ -305,7 +308,7 @@ impl<B: BufRead> Iterator for &mut Parser<B> {
 impl Parser<BufReader<File>> {
     pub fn from_file(xml_file: &Path) -> Self {
         let mut xml = XmlReader::from_file(xml_file).unwrap();
-        xml.trim_text(true);
+        xml.config_mut().trim_text(true);
 
         Parser {
             xml,
@@ -317,7 +320,7 @@ impl Parser<BufReader<File>> {
 impl<B: BufRead> Parser<B> {
     fn expect_text(&mut self) -> Result<String> {
         match self.xml.read_event_into(&mut self.buf)? {
-            XmlEv::Text(e) => Ok(str::from_utf8(e.unescape()?.as_bytes())?.into()),
+            XmlEv::Text(e) => text_content(e),
             XmlEv::CData(e) => Ok(str::from_utf8(&e)?.into()),
             ev => Err(Error::Parse(format!("expected text, found {:?}", ev))),
         }
@@ -325,7 +328,7 @@ impl<B: BufRead> Parser<B> {
 
     fn expect_text_trim(&mut self, close_tag: &[u8]) -> Result<String> {
         let txt = match self.xml.read_event_into(&mut self.buf)? {
-            XmlEv::Text(e) => Vec::from(e.unescape()?.as_bytes()),
+            XmlEv::Text(e) => text_content(e).map(String::into_bytes)?,
             XmlEv::CData(e) => Vec::from(e.into_inner()),
             XmlEv::End(e) => {
                 if e.name().0 == close_tag {
@@ -389,7 +392,7 @@ impl<B: BufRead> Parser<B> {
                         "expected </{}>, found {:?}",
                         str::from_utf8(tag).unwrap(),
                         ev
-                    )))
+                    )));
                 }
             }
         }
@@ -451,10 +454,8 @@ impl<B: BufRead> Parser<B> {
                 XmlEv::Text(_) | XmlEv::CData(_) => {
                     return Err(Error::Parse("Unexpected doc text out of element".into()));
                 }
-                XmlEv::End(ref e) => {
-                    if e.name().0 == b"doc" {
-                        break;
-                    }
+                XmlEv::End(ref e) if e.name().0 == b"doc" => {
+                    break;
                 }
                 _ => {}
             }
@@ -656,7 +657,7 @@ impl<B: BufRead> Parser<B> {
                         return Err(Error::Parse(format!(
                             "Unexpected </{}> in enum",
                             str::from_utf8(tag)?,
-                        )))
+                        )));
                     }
                 },
                 XmlEv::Comment(_) => {}
@@ -933,7 +934,7 @@ impl<B: BufRead> Parser<B> {
                             "Unexpected <{} /> in struct: {:?}",
                             str::from_utf8(tag)?,
                             e
-                        )))
+                        )));
                     }
                 },
                 XmlEv::End(ref e) => {
@@ -1047,7 +1048,7 @@ impl<B: BufRead> Parser<B> {
         let name = name.unwrap();
         let opcode = opcode.unwrap();
         let opcode: u32 = str::parse(&opcode)
-            .map_err(|_| Error::Parse(format!("cannot parse {} as int", &opcode)))?;
+            .map_err(|_| Error::Parse(format!("cannot parse {} as int", opcode)))?;
         if is_empty {
             Ok(Request {
                 name,
@@ -1110,7 +1111,7 @@ impl<B: BufRead> Parser<B> {
                     return Err(Error::Parse(format!(
                         "unexpected XML in switch case: {:?}",
                         ev
-                    )))
+                    )));
                 }
             }
         }
@@ -1150,10 +1151,8 @@ impl<B: BufRead> Parser<B> {
                         }
                     }
                 }
-                XmlEv::End(ref e) => {
-                    if e.name().0 == b"switch" {
-                        break;
-                    }
+                XmlEv::End(ref e) if e.name().0 == b"switch" => {
+                    break;
                 }
                 _ => {}
             }
@@ -1201,8 +1200,15 @@ fn is_expr_tag(tag: &[u8]) -> bool {
 }
 
 fn attr_value(attr: &Attribute) -> Result<String> {
-    let val = attr.unescape_value()?;
+    let val = attr.normalized_value(XmlVersion::Implicit1_0)?;
     Ok(str::from_utf8(val.as_bytes())?.into())
+}
+
+fn text_content(text: BytesText<'_>) -> Result<String> {
+    let decoded = text.xml10_content().map_err(quick_xml::Error::from)?;
+    Ok(escape::unescape(&decoded)
+        .map_err(quick_xml::Error::from)?
+        .into_owned())
 }
 
 fn expect_attribute(attrs: Attributes, name: &[u8]) -> Result<String> {

--- a/examples/opengl_window.rs
+++ b/examples/opengl_window.rs
@@ -78,6 +78,10 @@ fn get_glxfbconfig(
     }
 }
 
+fn raw_dpy(conn: &xcb::Connection) -> *mut xlib::Display {
+    conn.get_raw_dpy() as *mut xlib::Display
+}
+
 fn main() -> xcb::Result<()> {
     let (conn, screen_num) =
         xcb::Connection::connect_with_xlib_display_and_extensions(&[], &[xcb::Extension::Dri2])?;
@@ -91,7 +95,7 @@ fn main() -> xcb::Result<()> {
     assert!(glx_ver.major_version() >= 1 && glx_ver.minor_version() >= 3);
 
     let fbc = get_glxfbconfig(
-        conn.get_raw_dpy(),
+        raw_dpy(&conn),
         screen_num,
         &[
             GLX_X_RENDERABLE,
@@ -120,8 +124,7 @@ fn main() -> xcb::Result<()> {
         ],
     );
 
-    let vi_ptr: *mut xlib::XVisualInfo =
-        unsafe { glXGetVisualFromFBConfig(conn.get_raw_dpy(), fbc) };
+    let vi_ptr: *mut xlib::XVisualInfo = unsafe { glXGetVisualFromFBConfig(raw_dpy(&conn), fbc) };
     let vi = unsafe { *vi_ptr };
 
     // retrieving a few atoms
@@ -198,13 +201,12 @@ fn main() -> xcb::Result<()> {
     conn.check_request(conn.send_request_checked(&x::MapWindow { window: win }))?;
 
     unsafe {
-        xlib::XSync(conn.get_raw_dpy(), xlib::False);
+        xlib::XSync(raw_dpy(&conn), xlib::False);
     }
 
-    let glx_exts =
-        unsafe { CStr::from_ptr(glXQueryExtensionsString(conn.get_raw_dpy(), screen_num)) }
-            .to_str()
-            .unwrap();
+    let glx_exts = unsafe { CStr::from_ptr(glXQueryExtensionsString(raw_dpy(&conn), screen_num)) }
+        .to_str()
+        .unwrap();
 
     if !check_glx_extension(&glx_exts, "GLX_ARB_create_context") {
         panic!("could not find GLX extension GLX_ARB_create_context");
@@ -241,7 +243,7 @@ fn main() -> xcb::Result<()> {
     ];
     let ctx = unsafe {
         glx_create_context_attribs(
-            conn.get_raw_dpy(),
+            raw_dpy(&conn),
             fbc,
             ptr::null_mut(),
             xlib::True,
@@ -252,7 +254,7 @@ fn main() -> xcb::Result<()> {
     conn.flush()?;
 
     unsafe {
-        xlib::XSync(conn.get_raw_dpy(), xlib::False);
+        xlib::XSync(raw_dpy(&conn), xlib::False);
         xlib::XSetErrorHandler(std::mem::transmute(old_handler));
     }
 
@@ -260,7 +262,7 @@ fn main() -> xcb::Result<()> {
         panic!("error when creating gl-3.0 context");
     }
 
-    if unsafe { glXIsDirect(conn.get_raw_dpy(), ctx) } == 0 {
+    if unsafe { glXIsDirect(raw_dpy(&conn), ctx) } == 0 {
         panic!("obtained indirect rendering context")
     }
 
@@ -269,13 +271,13 @@ fn main() -> xcb::Result<()> {
 
         match conn.wait_for_event()? {
             xcb::Event::X(x::Event::Expose(_)) => unsafe {
-                glXMakeCurrent(conn.get_raw_dpy(), win.resource_id() as xlib::XID, ctx);
+                glXMakeCurrent(raw_dpy(&conn), win.resource_id() as xlib::XID, ctx);
                 gl::ClearColor(0.5f32, 0.5f32, 1.0f32, 1.0f32);
                 gl::Clear(gl::COLOR_BUFFER_BIT);
                 gl::Flush();
                 check_gl_error();
-                glXSwapBuffers(conn.get_raw_dpy(), win.resource_id() as xlib::XID);
-                glXMakeCurrent(conn.get_raw_dpy(), 0, ptr::null_mut());
+                glXSwapBuffers(raw_dpy(&conn), win.resource_id() as xlib::XID);
+                glXMakeCurrent(raw_dpy(&conn), 0, ptr::null_mut());
             },
             xcb::Event::X(x::Event::KeyPress(_ev)) => {}
             xcb::Event::X(x::Event::ClientMessage(ev)) => {
@@ -308,7 +310,7 @@ fn main() -> xcb::Result<()> {
     }
 
     unsafe {
-        glXDestroyContext(conn.get_raw_dpy(), ctx);
+        glXDestroyContext(raw_dpy(&conn), ctx);
     }
 
     conn.send_request(&x::UnmapWindow { window: win });
@@ -322,12 +324,12 @@ fn main() -> xcb::Result<()> {
 unsafe fn rewire_event(conn: &xcb::Connection, raw_ev: *mut xcb_generic_event_t) {
     let ev_type = ((*raw_ev).response_type & 0x7f) as i32;
 
-    if let Some(proc) = xlib::XESetWireToEvent(conn.get_raw_dpy(), ev_type, None) {
-        xlib::XESetWireToEvent(conn.get_raw_dpy(), ev_type, Some(proc));
-        (*raw_ev).sequence = xlib::XLastKnownRequestProcessed(conn.get_raw_dpy()) as u16;
+    if let Some(proc) = xlib::XESetWireToEvent(raw_dpy(conn), ev_type, None) {
+        xlib::XESetWireToEvent(raw_dpy(conn), ev_type, Some(proc));
+        (*raw_ev).sequence = xlib::XLastKnownRequestProcessed(raw_dpy(conn)) as u16;
         let mut dummy: xlib::XEvent = std::mem::zeroed();
         proc(
-            conn.get_raw_dpy(),
+            raw_dpy(conn),
             &mut dummy as *mut xlib::XEvent,
             raw_ev as *mut xlib::xEvent,
         );

--- a/src/base.rs
+++ b/src/base.rs
@@ -2343,6 +2343,7 @@ unsafe fn is_error(ev: *mut xcb_generic_event_t) -> bool {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub(crate) struct RequestFlags: u32 {
         const NONE = 0;
         const CHECKED = 1;


### PR DESCRIPTION
## Summary

- Update dependency version requirements for `quick-xml`, `bitflags`, `x11`, `x11-dl`, `png`, and `tiny-xlib`.
- Adjust code generation and XML parsing for `quick-xml 0.41` and `bitflags 2`. This would resolve various CVEs related to `quick-xml < 0.41` (please run `cargo audit` on the base repo for reference).
- Fix the OpenGL example so it compiles with all features enabled.
- Replace archived `actions-rs/*` GitHub Actions with `moonrepo/setup-rust` and plain `cargo` commands.
- Update `actions/checkout` from `v2` to `v7`.

## Verification

- `cargo fmt`
- `cargo test --all-features`